### PR TITLE
Enable customization of individual node settings

### DIFF
--- a/vagrant-pxe-harvester/Vagrantfile
+++ b/vagrant-pxe-harvester/Vagrantfile
@@ -21,15 +21,6 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = "libvirt"
 @root_dir = File.dirname(File.expand_path(__FILE__))
 @settings = YAML.load_file(File.join(@root_dir, "settings.yml"))
 
-# make sure we have a supported cluster configuration
-if not [1, 3].include? @settings['harvester_cluster_nodes']
-  STDERR.puts "#{@settings['harvester_cluster_nodes']} is not a supported " \
-              "configuration for 'harvester_cluster_nodes'. It must " \
-              "be either '1' or '3'."
-  exit(1)
-end
-
-
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   
   config.vm.define :pxe_server do |pxe_server|
@@ -60,20 +51,22 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   cluster_node_index = @settings['harvester_cluster_nodes'] - 1
   (0..cluster_node_index).each do |node_number|
-    vm_name = "harvester_node_#{node_number}"
+    vm_name = "harvester-node-#{node_number}"
     config.vm.define vm_name, autostart: false do |harvester_node|
       harvester_node.vm.hostname = "harvester-node-#{node_number}"
       harvester_node.vm.network 'private_network',
         libvirt__network_name: 'harvester',
         mac: @settings['harvester_network_config']['cluster'][node_number]['mac']
+      harvester_node.vm.network 'private_network',
+        libvirt__network_name: 'harvester'
 
       harvester_node.vm.provider :libvirt do |libvirt|
         libvirt.cpu_mode = 'host-passthrough'
-        libvirt.memory = @settings['harvester_node_config']['memory'] 
-        libvirt.cpus = @settings['harvester_node_config']['cpu']
+        libvirt.memory = @settings['harvester_network_config']['cluster'][node_number].key?('memory') ? @settings['harvester_network_config']['cluster'][node_number]['memory'] : @settings['harvester_node_config']['memory'] 
+        libvirt.cpus = @settings['harvester_network_config']['cluster'][node_number].key?('cpu') ? @settings['harvester_network_config']['cluster'][node_number]['cpu'] : @settings['harvester_node_config']['cpu']
         # NOTE: device must set to 'sda'
         libvirt.storage :file,
-          size: @settings['harvester_node_config']['disk_size'],
+          size: @settings['harvester_network_config']['cluster'][node_number].key?('disk_size') ? @settings['harvester_network_config']['cluster'][node_number]['disk_size'] : @settings['harvester_node_config']['disk_size'],
           type: 'qcow2',
           bus: 'sata',
           device: 'sda'

--- a/vagrant-pxe-harvester/ansible/boot_harvester_node.yml
+++ b/vagrant-pxe-harvester/ansible/boot_harvester_node.yml
@@ -10,12 +10,12 @@
 
 - name: boot Harvester Node {{ node_number }}
   shell: >
-    vagrant up harvester_node_{{ node_number }}
+    vagrant up harvester-node-{{ node_number }}
   register: harvester_node_boot_result
 
 - name: get the IP address of Harvester Node {{ node_number }}
   shell: |
-    vagrant ssh-config harvester_node_{{ node_number }} 2>/dev/null | grep HostName | awk '{ print $2 }'
+    vagrant ssh-config harvester-node-{{ node_number }} 2>/dev/null | grep HostName | awk '{ print $2 }'
   register: get_harvester_node_ip_result
   until: get_harvester_node_ip_result.stdout != ""
   retries: 10

--- a/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
+++ b/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
@@ -24,7 +24,7 @@ subnet {{ settings['harvester_network_config']['dhcp_server']['subnet'] }} netma
     }
 }
 
-{% for node_number in range(3) %}
+{% for node_number in range(settings['harvester_cluster_nodes']) %}
 host harvest_node_{{ node_number }} {
     hardware ethernet {{ settings['harvester_network_config']['cluster'][node_number]['mac'] }};
     fixed-address {{ settings['harvester_network_config']['cluster'][node_number]['ip'] }};

--- a/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
@@ -4,30 +4,28 @@
     path: /var/www/harvester
     state: directory
 
-- name: download Harvester kernel
-  include: _download_media.yml
-  vars:
-    harvester_media_url: "{{ settings['harvester_kernel_url'] }}"
-
-- name: download Harvester ramdisk
-  include: _download_media.yml
-  vars:
-    harvester_media_url: "{{ settings['harvester_ramdisk_url'] }}"
-
-- name: download Harvester ISO
-  include: _download_media.yml
-  vars:
-    harvester_media_url: "{{ settings['harvester_iso_url'] }}"
-
-- name: copy config-create.yml and config-join.yml
+- name: copy config-create.yaml
   template:
-    src: "{{ item }}.j2"
-    dest: /var/www/harvester/{{ item }}
+    src: "config-create.yaml.j2"
+    dest: /var/www/harvester/config-create.yaml
     owner: www-data
     mode: 0640
-  with_items:
-    - config-create.yaml
-    - config-join.yaml
+
+# NOTE(gyee): Ansible pre-process the with_sequence variable so we have to
+# make sure end sequence is at least 1 even if we have only one Harvester node
+- name: set node sequence fact
+  set_fact:
+    end_sequence: "{{ settings['harvester_cluster_nodes'] - 1 if settings['harvester_cluster_nodes'] > 1 else 1 }}"
+
+- name: copy config-join.yaml
+  template:
+    src: "config-join.yaml.j2"
+    dest: /var/www/harvester/config-join-{{ item }}.yaml
+    owner: www-data
+    mode: 0640
+  vars:
+    node_number: "{{ item }}"
+  with_sequence: "start=1 end={{ end_sequence }}"
 
 - name: chown dir
   file:
@@ -44,4 +42,21 @@
   template:
     src: ipxe-join.j2
     dest: /var/www/harvester/{{ settings['harvester_network_config']['cluster'][item|int]['mac']|lower }}
-  with_sequence: 1-2
+  vars:
+    node_number: "{{ item }}"
+  with_sequence: "start=1 end={{ end_sequence }}"
+
+- name: download Harvester kernel
+  include: _download_media.yml
+  vars:
+    harvester_media_url: "{{ settings['harvester_kernel_url'] }}"
+
+- name: download Harvester ramdisk
+  include: _download_media.yml
+  vars:
+    harvester_media_url: "{{ settings['harvester_ramdisk_url'] }}"
+
+- name: download Harvester ISO
+  include: _download_media.yml
+  vars:
+    harvester_media_url: "{{ settings['harvester_iso_url'] }}"

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
@@ -2,6 +2,7 @@
 
 token: {{ settings['harvester_config']['token'] }}
 os:
+  hostname: harvester-node-0
   ssh_authorized_keys:
 {% for ssh_key in settings['harvester_config']['ssh_authorized_keys'] %}
     - {{ ssh_key }}
@@ -9,7 +10,7 @@ os:
   password: {{ settings['harvester_config']['password'] }}
 install:
   mode: create
-  mgmt_interface: eth0   # The management interface name
+  mgmt_interface: eth1   # The management interface name
   device: /dev/sda       # The target disk to install
   iso_url: http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-amd64.iso
 #  tty: ttyS1,115200n8   # For machines without a VGA console

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -3,6 +3,7 @@
 server_url: https://{{ settings['harvester_network_config']['cluster'][0]['ip'] }}:6443
 token: {{ settings['harvester_config']['token'] }}
 os:
+  hostname: harvester-node-{{ node_number }}
   ssh_authorized_keys:
 {% for ssh_key in settings['harvester_config']['ssh_authorized_keys'] %}
     - {{ ssh_key }}
@@ -10,7 +11,7 @@ os:
   password: {{ settings['harvester_config']['password'] }}
 install:
   mode: join
-  mgmt_interface: eth0   # The management interface name
+  mgmt_interface: eth1   # The management interface name
   device: /dev/sda       # The target disk to install
   iso_url: http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-amd64.iso
 #  tty: ttyS1,115200n8   # For machines without a VGA console

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-join.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-join.j2
@@ -2,5 +2,5 @@
 
 kernel http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-vmlinuz-amd64
 initrd http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-initrd-amd64
-imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 k3os.mode=install k3os.debug console=tty0 harvester.install.automatic=true harvester.install.config_url=http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/config-join.yaml
+imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 k3os.mode=install k3os.debug console=tty0 harvester.install.automatic=true harvester.install.config_url=http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/config-join-{{ node_number }}.yaml
 boot

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -19,12 +19,9 @@ harvester_ramdisk_url: https://releases.rancher.com/harvester/master/harvester-i
 #
 # harvester_cluster_nodes
 #
-# Supported values are:
+# NOTE: keep in mind that you need at least 3 nodes to make a cluster
 #
-#  * 1: single node, no HA
-#  * 3: 3-node cluster, HA
-#
-harvester_cluster_nodes: 1
+harvester_cluster_nodes: 3
 
 #
 # network_config
@@ -45,16 +42,28 @@ harvester_network_config:
     ip: 192.168.0.254
     subnet: 192.168.0.0
     netmask: 255.255.255.0
-    range: 192.168.0.10 192.168.0.20
+    range: 192.168.0.50 192.168.0.130
   # Reserve these IPs for the Harvester cluster. Make sure these are outside
   # the range of DHCP so they don't get served out by the DHCP server
   cluster:
     - ip: 192.168.0.30
       mac: 02:00:00:0D:62:E2
+      cpu: 2
+      memory: 8192
+      disk_size: 50G
     - ip: 192.168.0.31
       mac: 02:00:00:35:86:92
+      cpu: 2
+      memory: 8192
+      disk_size: 30G
     - ip: 192.168.0.32
       mac: 02:00:00:2F:F2:2A
+      cpu: 6
+      memory: 16384
+    - ip: 192.168.0.33
+      mac: 02:00:00:A7:E6:FF
+      cpu: 2
+      memory: 8192
 
 #
 # harvester_config


### PR DESCRIPTION
To be able to test Harvester VM scheduling behavior (e.g. schedule
VMs on the nodes that has the available resource), we need to be able
to customize each node's CPU and memory so we can simulation various
resource utilization scenarios.