### PR TITLE
Add capability to reinstall a single Harvester node + new OS updates

### DIFF
--- a/vagrant-pxe-harvester/ansible/boot_harvester_node.yml
+++ b/vagrant-pxe-harvester/ansible/boot_harvester_node.yml
@@ -8,28 +8,21 @@
   debug:
     msg: "{{ figlet_result.stdout }}"
 
+- name: set Harvester Node IP fact
+  set_fact:
+    harvester_node_ip: "{{ harvester_network_config['cluster'][node_number | int]['ip'] }}"
+
 - name: boot Harvester Node {{ node_number }}
   shell: >
     vagrant up harvester-node-{{ node_number }}
   register: harvester_node_boot_result
-
-- name: get the IP address of Harvester Node {{ node_number }}
-  shell: |
-    vagrant ssh-config harvester-node-{{ node_number }} 2>/dev/null | grep HostName | awk '{ print $2 }'
-  register: get_harvester_node_ip_result
-  until: get_harvester_node_ip_result.stdout != ""
-  retries: 10
-  delay: 60
-
-- name: set Harvester Node IP fact
-  set_fact:
-    harvester_node_ip: "{{ get_harvester_node_ip_result.stdout }}"
 
 - name: wait for Harvester Node {{ harvester_node_ip }} to get ready
   uri:
     url: "https://{{ harvester_node_ip }}:30443"
     validate_certs: no
     status_code: 200
+    timeout: 120
   register: auth_modes_lookup_result
   until: auth_modes_lookup_result.status == 200
   retries: 20

--- a/vagrant-pxe-harvester/ansible/reinstall_harvester_node.yml
+++ b/vagrant-pxe-harvester/ansible/reinstall_harvester_node.yml
@@ -1,0 +1,27 @@
+---
+- name: Reinstall Harvester Node
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+  - name: create "Reinstalling Harvester Node" message
+    shell: >
+      figlet "Reinstalling Harvester Node {{ node_number }}" 2>/dev/null || echo "Reinstalling Harvester Node {{ node_number }}"
+    register: figlet_result
+
+  - name: print "Reinstalling Harvester Node" message
+    debug:
+      msg: "{{ figlet_result.stdout }}"
+
+  - name: boot Harvester nodes
+    include: boot_harvester_node.yml
+
+  - name: create "Installation Completed" message
+    shell: >
+      figlet "Installation Completed" 2>/dev/null || echo "Installation Completed"
+    register: figlet_result
+
+  - name: print "Installation Completed"
+    debug:
+      msg: "{{ figlet_result.stdout }}"

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
@@ -11,7 +11,10 @@ os:
 install:
   mode: create
   mgmt_interface: eth1   # The management interface name
+  networks:
+    - interface: eth0
+      method: dhcp
   device: /dev/sda       # The target disk to install
-  iso_url: http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-amd64.iso
+  iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso
 #  tty: ttyS1,115200n8   # For machines without a VGA console
   tty: ttyS0

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -1,6 +1,6 @@
 # example from https://github.com/harvester/ipxe-examples/blob/main/general/config-join.yaml
 
-server_url: https://{{ settings['harvester_network_config']['cluster'][0]['ip'] }}:6443
+server_url: https://{{ settings['harvester_network_config']['cluster'][0]['ip'] }}:8443
 token: {{ settings['harvester_config']['token'] }}
 os:
   hostname: harvester-node-{{ node_number }}
@@ -12,7 +12,10 @@ os:
 install:
   mode: join
   mgmt_interface: eth1   # The management interface name
+  networks:
+    - interface: eth0
+      method: dhcp
   device: /dev/sda       # The target disk to install
-  iso_url: http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-amd64.iso
+  iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso
 #  tty: ttyS1,115200n8   # For machines without a VGA console
   tty: ttyS0

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-create.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-create.j2
@@ -2,5 +2,5 @@
 
 kernel http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-vmlinuz-amd64
 initrd http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-initrd-amd64
-imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 k3os.mode=install k3os.debug console=tty0 harvester.install.automatic=true harvester.install.config_url=http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/config-create.yaml
+imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 ip=dhcp rd.cos.disable rd.live.debug=1 rd.noverifyssl root=live:https://releases.rancher.com/harvester/master/harvester-rootfs-amd64.squashfs console=tty1 harvester.install.automatic=true harvester.install.config_url=http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/config-create.yaml
 boot

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-join.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-join.j2
@@ -2,5 +2,5 @@
 
 kernel http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-vmlinuz-amd64
 initrd http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-initrd-amd64
-imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 k3os.mode=install k3os.debug console=tty0 harvester.install.automatic=true harvester.install.config_url=http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/config-join-{{ node_number }}.yaml
+imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 ip=dhcp rd.cos.disable rd.live.debug=1 rd.noverifyssl root=live:https://releases.rancher.com/harvester/master/harvester-rootfs-amd64.squashfs console=tty1 harvester.install.automatic=true harvester.install.config_url=http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/config-join-{{ node_number }}.yaml
 boot

--- a/vagrant-pxe-harvester/reinstall_harvester_node.sh
+++ b/vagrant-pxe-harvester/reinstall_harvester_node.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+MYNAME=$0
+ROOTDIR=$(dirname $(readlink -e $MYNAME))
+
+USAGE="${0}: <node number>
+
+Where:
+
+  <node number>: node to re-install. Node number starts with zero (0). For
+                 example, if you want to re-install the 3rd node, the node
+                 number given should be 2.
+"
+
+if [ $# -ne 1 ] ; then
+  echo "$USAGE"
+  exit 1
+fi
+
+NODE_NUMBER=$1
+NODE_NAME="harvester-node-${NODE_NUMBER}"
+
+# check to make sure the node has not been created
+NOT_CREATED=`vagrant status ${NODE_NAME} | grep "^${NODE_NAME}" | grep "not created" || true`
+
+if [ "${NOT_CREATED}" == "" ] ; then
+  echo "Harvester node ${NODE_NAME} already created."
+  exit 1
+fi
+
+pushd $ROOTDIR
+ansible-playbook ansible/reinstall_harvester_node.yml --extra-vars "@settings.yml" --extra-vars "node_number=${NODE_NUMBER}"
+popd

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -48,14 +48,14 @@ harvester_network_config:
   cluster:
     - ip: 192.168.0.30
       mac: 02:00:00:0D:62:E2
-      cpu: 2
+      cpu: 4
       memory: 8192
-      disk_size: 50G
+      disk_size: 60G
     - ip: 192.168.0.31
       mac: 02:00:00:35:86:92
-      cpu: 2
+      cpu: 4
       memory: 8192
-      disk_size: 30G
+      disk_size: 80G
     - ip: 192.168.0.32
       mac: 02:00:00:2F:F2:2A
       cpu: 6


### PR DESCRIPTION
It is needed to facilitate testing disaster recovery scenarios. This patch also update the playbooks to work with the new OS image.