### PR TITLE
Fix ansible privilege escalation

### DIFF
--- a/vagrant-pxe-harvester/ansible.cfg
+++ b/vagrant-pxe-harvester/ansible.cfg
@@ -1,5 +1,3 @@
 [defaults]
 stdout_callback = yaml
 interpreter_python = auto_silent
-[privilege_escalation]
-become = True

--- a/vagrant-pxe-harvester/ansible/setup_pxe_server.yml
+++ b/vagrant-pxe-harvester/ansible/setup_pxe_server.yml
@@ -1,4 +1,5 @@
 - hosts: all
+  become: yes
   tasks:
     - name: install kitty terminfo
       apt:


### PR DESCRIPTION
There's no need to run all the plays in escalated privilege. We should only
escalate when needed.