### PR TITLE
Allow NIC to be configurable

### DIFF
--- a/vagrant-pxe-harvester/README.md
+++ b/vagrant-pxe-harvester/README.md
@@ -17,7 +17,7 @@ Prerequisites
 -   vagrant-libvirt plugin \>= 0.0.43.
 -   KVM (i.e. qemu-kvm), preferably the latest and greatest. This
     environment was tested with qemu-kvm 2.11.
--   Host with at least 16GB RAM & 500GB free disk space.
+-   Host with at least 16 CPU, 64GB RAM, and 500GB free disk space.
 
 Quick Start
 -----------
@@ -28,14 +28,11 @@ Quick Start
     depending on configuration).
 3.  If successful, run `vagrant status` to see the status of the Vagrant
     boxes.
-4.  Get the public IP of the first Harvester node:
-    ```console
-    vagrant ssh-config harvester_node_0
-    ```
-
-5.  Point your browser to `https://<harvester_node_0 IP>:30443` to
+4.  Point your browser to `https://<harvester_vip>:30443` to
     access the Harvester UI. Just ignore the scary SSL warnings for now
     as it is using self-signed certificates for demo purposes.
+    *NOTE*: by default `harvester_vip` is `192.168.0.131`. However, it is
+    configureable in `settings.yml`.
 
 Acknowledgements
 ----------------

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
@@ -10,9 +10,9 @@ os:
   password: {{ settings['harvester_config']['password'] }}
 install:
   mode: create
-  mgmt_interface: eth1   # The management interface name
+  mgmt_interface: {{ settings['harvester_network_config']['cluster'][0]['mgmt_interface'] }}  # The management interface name
   networks:
-    - interface: eth0
+    - interface: {{ settings['harvester_network_config']['cluster'][0]['vagrant_interface'] }}
       method: dhcp
   device: /dev/sda       # The target disk to install
   iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -11,9 +11,9 @@ os:
   password: {{ settings['harvester_config']['password'] }}
 install:
   mode: join
-  mgmt_interface: eth1   # The management interface name
+  mgmt_interface: {{ settings['harvester_network_config']['cluster'][node_number | int]['mgmt_interface'] }}   # The management interface name
   networks:
-    - interface: eth0
+    - interface: {{ settings['harvester_network_config']['cluster'][node_number | int]['vagrant_interface'] }}
       method: dhcp
   device: /dev/sda       # The target disk to install
   iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -55,19 +55,29 @@ harvester_network_config:
       cpu: 4
       memory: 16384
       disk_size: 60G
+      vagrant_interface: ens5
+      mgmt_interface: ens6
     - ip: 192.168.0.31
       mac: 02:00:00:35:86:92
       cpu: 4
       memory: 8192
       disk_size: 80G
+      vagrant_interface: ens5
+      mgmt_interface: ens6
     - ip: 192.168.0.32
       mac: 02:00:00:2F:F2:2A
       cpu: 6
       memory: 16384
+      disk_size: 100G
+      vagrant_interface: ens5
+      mgmt_interface: ens6
     - ip: 192.168.0.33
       mac: 02:00:00:A7:E6:FF
-      cpu: 2
+      cpu: 4
       memory: 8192
+      disk_size: 80G
+      vagrant_interface: ens5
+      mgmt_interface: ens6
 
 #
 # harvester_config


### PR DESCRIPTION
With the latest networking changes (1), user must first find out
the name of the NICs to enable, then enable them accordingly.
This PR enables user to configure the NICs in settings.yml.
Notice that the NIC names maybe different from server to server.

1. https://github.com/harvester/harvester-installer/pull/118