### PR TITLE
Renaming media files to fixed name

### DIFF
--- a/vagrant-pxe-harvester/ansible/roles/harvester/tasks/_download_media.yml
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/tasks/_download_media.yml
@@ -6,11 +6,11 @@
 - name: copy Harvester media from local directory
   copy:
     src: "{{ harvester_download_url_facts['path'] }}"
-    dest: /var/www/harvester/
+    dest: /var/www/harvester/{{ media_filename }}
   when: harvester_download_url_facts['scheme']|lower == 'file'
 
 - name: download Harvester media
   get_url:
     url: "{{ harvester_media_url }}"
-    dest: /var/www/harvester/
+    dest: /var/www/harvester/{{ media_filename }}
   when: harvester_download_url_facts['scheme']|lower != 'file'

--- a/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
@@ -50,13 +50,16 @@
   include: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_kernel_url'] }}"
+    media_filename: "harvester-vmlinuz-amd64"
 
 - name: download Harvester ramdisk
   include: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_ramdisk_url'] }}"
+    media_filename: "harvester-initrd-amd64"
 
 - name: download Harvester ISO
   include: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_iso_url'] }}"
+    media_filename: "harvester-amd64.iso"


### PR DESCRIPTION
Renaming downloaded media files to the fixed name, then we can use arbitrary URI string in `settings.yml`
This will only affect to `ipxe-example`.

The example of `v.0.3.0-preview1`:
```yml
harvester_iso_url: https://releases.rancher.com/harvester/v0.3.0-preview1/harvester-v0.3.0-preview1-amd64.iso
harvester_kernel_url: https://releases.rancher.com/harvester/v0.3.0-preview1/harvester-v0.3.0-preview1-vmlinuz-amd64
harvester_ramdisk_url: https://releases.rancher.com/harvester/v0.3.0-preview1/harvester-v0.3.0-preview1-initrd-amd64
```
those files will be renamed to
```yml
harvester_iso_url: harvester-amd64.iso
harvester_kernel_url: harvester-vmlinuz-amd64
harvester_ramdisk_url: harvester-initrd-amd64
```