### PR TITLE
Allow rootfs URL to be configurable

### DIFF
--- a/vagrant-pxe-harvester/ansible/boot_harvester_node.yml
+++ b/vagrant-pxe-harvester/ansible/boot_harvester_node.yml
@@ -26,4 +26,4 @@
   register: auth_modes_lookup_result
   until: auth_modes_lookup_result.status == 200
   retries: 20
-  delay: 60
+  delay: 120

--- a/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
@@ -63,3 +63,9 @@
   vars:
     harvester_media_url: "{{ settings['harvester_iso_url'] }}"
     media_filename: "harvester-amd64.iso"
+
+- name: download Harvester Root FS
+  include: _download_media.yml
+  vars:
+    harvester_media_url: "{{ settings['harvester_rootfs_url'] }}"
+    media_filename: "harvester-rootfs-amd64.squashfs"

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-create.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-create.j2
@@ -2,5 +2,5 @@
 
 kernel http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-vmlinuz-amd64
 initrd http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-initrd-amd64
-imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 ip=dhcp net.ifnames=1 rd.cos.disable rd.live.debug=1 rd.noverifyssl root=live:https://releases.rancher.com/harvester/master/harvester-rootfs-amd64.squashfs console=tty1 harvester.install.automatic=true harvester.install.config_url=http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/config-create.yaml
+imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 ip=dhcp net.ifnames=1 rd.cos.disable rd.live.debug=1 rd.noverifyssl root=live:http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-rootfs-amd64.squashfs console=tty1 harvester.install.automatic=true harvester.install.config_url=http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/config-create.yaml
 boot

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-join.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-join.j2
@@ -2,5 +2,5 @@
 
 kernel http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-vmlinuz-amd64
 initrd http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-initrd-amd64
-imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 ip=dhcp net.ifnames=1 rd.cos.disable rd.live.debug=1 rd.noverifyssl root=live:https://releases.rancher.com/harvester/master/harvester-rootfs-amd64.squashfs console=tty1 harvester.install.automatic=true harvester.install.config_url=http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/config-join-{{ node_number }}.yaml
+imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 ip=dhcp net.ifnames=1 rd.cos.disable rd.live.debug=1 rd.noverifyssl root=live:http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-rootfs-amd64.squashfs console=tty1 harvester.install.automatic=true harvester.install.config_url=http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/config-join-{{ node_number }}.yaml
 boot

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -15,6 +15,7 @@
 harvester_iso_url: https://releases.rancher.com/harvester/master/harvester-amd64.iso
 harvester_kernel_url: https://releases.rancher.com/harvester/master/harvester-vmlinuz-amd64
 harvester_ramdisk_url: https://releases.rancher.com/harvester/master/harvester-initrd-amd64
+harvester_rootfs_url: https://releases.rancher.com/harvester/master/harvester-rootfs-amd64.squashfs
 
 #
 # harvester_cluster_nodes


### PR DESCRIPTION
Rootfs media seem to be release-specific so it should be configurable,
just as the rest of the release media.