### PR TITLE
Specify DHCP interface

### DIFF
--- a/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
@@ -37,6 +37,8 @@
   template:
     src: ipxe-create.j2
     dest: /var/www/harvester/{{ settings['harvester_network_config']['cluster'][0]['mac']|lower }}
+  vars:
+    boot_interface: "{{ settings['harvester_network_config']['cluster'][0]['vagrant_interface'] }}"
 
 - name: create boot entry for the cluster members
   template:
@@ -44,6 +46,7 @@
     dest: /var/www/harvester/{{ settings['harvester_network_config']['cluster'][item|int]['mac']|lower }}
   vars:
     node_number: "{{ item }}"
+    boot_interface: "{{ settings['harvester_network_config']['cluster'][item|int]['vagrant_interface'] }}"
   with_sequence: "start=1 end={{ end_sequence }}"
 
 - name: download Harvester kernel

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-create.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-create.j2
@@ -2,5 +2,5 @@
 
 kernel http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-vmlinuz-amd64
 initrd http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-initrd-amd64
-imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 ip=dhcp net.ifnames=1 rd.cos.disable rd.live.debug=1 rd.noverifyssl root=live:http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-rootfs-amd64.squashfs console=tty1 harvester.install.automatic=true harvester.install.config_url=http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/config-create.yaml
+imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 ip={{ boot_interface }}:dhcp net.ifnames=1 rd.cos.disable rd.live.debug=1 rd.noverifyssl root=live:http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-rootfs-amd64.squashfs console=tty1 harvester.install.automatic=true harvester.install.config_url=http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/config-create.yaml
 boot

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-join.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-join.j2
@@ -2,5 +2,5 @@
 
 kernel http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-vmlinuz-amd64
 initrd http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-initrd-amd64
-imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 ip=dhcp net.ifnames=1 rd.cos.disable rd.live.debug=1 rd.noverifyssl root=live:http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-rootfs-amd64.squashfs console=tty1 harvester.install.automatic=true harvester.install.config_url=http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/config-join-{{ node_number }}.yaml
+imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 ip={{ boot_interface }}:dhcp net.ifnames=1 rd.cos.disable rd.live.debug=1 rd.noverifyssl root=live:http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-rootfs-amd64.squashfs console=tty1 harvester.install.automatic=true harvester.install.config_url=http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/config-join-{{ node_number }}.yaml
 boot


### PR DESCRIPTION
Using ip=dhcp is not recommended when there are more than one DHCP networks.

The behavior of `ip=dhcp` is not stable. The VM has 3 interfaces:
- `ens5`: `libvirt-vagrant` network
- `ens6`: `harvester` network. IPs are allocated according to MACs.
- `ens7`: also `harvester` network. IPs are also allocated if request.

If we use `ip=dhcp` parameter, In initramfs stage, the Dracut module tries to get IPs from all interfaces. The result is not stable, sometimes `ens5` and `ens6` get IPs. Sometimes only `ens7` get IPs. We should use a fixed one.

