### PR TITLE
New config for NIC bonding

### DIFF
--- a/equinix/README.md
+++ b/equinix/README.md
@@ -47,7 +47,13 @@ The `harvester.install.config_url=https://metadata.platformequinix.com/userdata`
       password: p@ssword  # replace with a your password
     install:
       mode: create
-      mgmt_interface: eth0
+      networks:
+        harvester-mgmt: # The management bond name. This is mandatory.
+          bond_option:
+            mode: balance-tlb
+          interfaces:
+          - name: eth0
+          method: dhcp
       device: /dev/sda
       iso_url: https://releases.rancher.com/harvester/master/harvester-amd64.iso
       tty: ttyS1,115200n8
@@ -76,7 +82,13 @@ os:
   password: p@ssword  # replace with a your password
 install:
   mode: join
-  mgmt_interface: eth0
+  networks:
+    harvester-mgmt: # The management bond name. This is mandatory.
+      bond_option:
+        mode: balance-tlb
+      interfaces:
+      - name: eth0
+      method: dhcp
   device: /dev/sda
   iso_url: https://releases.rancher.com/harvester/master/harvester-amd64.iso
   tty: ttyS1,115200n

--- a/equinix/userdata-create.yaml
+++ b/equinix/userdata-create.yaml
@@ -6,7 +6,13 @@ os:
   password: p@ssword   # replace with a your password
 install:
   mode: create
-  mgmt_interface: eth0
+  networks:
+    harvester-mgmt:    # The management bond name. This is mandatory.
+      bond_option:
+        mode: balance-tlb
+      interfaces:
+      - name: eth0
+      method: dhcp
   device: /dev/sda
   iso_url: https://releases.rancher.com/harvester/master/harvester-amd64.iso
   tty: ttyS1,115200n8

--- a/equinix/userdata-join.yaml
+++ b/equinix/userdata-join.yaml
@@ -7,7 +7,13 @@ os:
   password: p@ssword   # replace with a your password
 install:
   mode: join
-  mgmt_interface: eth0
+  networks:
+    harvester-mgmt:    # The management bond name. This is mandatory.
+      bond_option:
+        mode: balance-tlb
+      interfaces:
+      - name: eth0
+      method: dhcp
   device: /dev/sda
   iso_url: https://releases.rancher.com/harvester/master/harvester-amd64.iso
   tty: ttyS1,115200n8

--- a/general/config-create.yaml
+++ b/general/config-create.yaml
@@ -6,7 +6,13 @@ os:
   password: p@ssword     # Replace with a your password
 install:
   mode: create
-  mgmt_interface: eth0   # The management interface name
+  networks:
+    harvester-mgmt:      # The management bond name. This is mandatory.
+      bond_option:
+        mode: balance-tlb
+      interfaces:
+      - name: eth0
+      method: dhcp
   device: /dev/sda       # The target disk to install
   iso_url: https://releases.rancher.com/harvester/master/harvester-amd64.iso
 #  tty: ttyS1,115200n8   # For machines without a VGA console

--- a/general/config-join.yaml
+++ b/general/config-join.yaml
@@ -7,7 +7,13 @@ os:
   password: p@ssword     # Replace with a your password
 install:
   mode: join
-  mgmt_interface: eth0   # The management interface name
+  networks:
+    harvester-mgmt:      # The management bond name. This is mandatory.
+      bond_option:
+        mode: balance-tlb
+      interfaces:
+      - name: eth0
+      method: dhcp
   device: /dev/sda       # The target disk to install
   iso_url: https://releases.rancher.com/harvester/master/harvester-amd64.iso
 #  tty: ttyS1,115200n8   # For machines without a VGA console

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
@@ -10,9 +10,14 @@ os:
   password: {{ settings['harvester_config']['password'] }}
 install:
   mode: create
-  mgmt_interface: {{ settings['harvester_network_config']['cluster'][0]['mgmt_interface'] }}  # The management interface name
   networks:
-    - interface: {{ settings['harvester_network_config']['cluster'][0]['vagrant_interface'] }}
+    {{ settings['harvester_network_config']['cluster'][0]['vagrant_interface'] }}:
+      method: dhcp
+    harvester-mgmt: # The management bond name. This is mandatory.
+      bond_option:
+        mode: balance-tlb
+      interfaces:
+      - name: {{ settings['harvester_network_config']['cluster'][0]['mgmt_interface'] }}
       method: dhcp
   device: /dev/sda       # The target disk to install
   iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -11,9 +11,14 @@ os:
   password: {{ settings['harvester_config']['password'] }}
 install:
   mode: join
-  mgmt_interface: {{ settings['harvester_network_config']['cluster'][node_number | int]['mgmt_interface'] }}   # The management interface name
   networks:
-    - interface: {{ settings['harvester_network_config']['cluster'][node_number | int]['vagrant_interface'] }}
+    {{ settings['harvester_network_config']['cluster'][node_number | int]['vagrant_interface'] }}:
+      method: dhcp
+    harvester-mgmt: # The management bond name. This is mandatory.
+      bond_option:
+        mode: balance-tlb
+      interfaces:
+      - name: {{ settings['harvester_network_config']['cluster'][node_number | int]['mgmt_interface'] }}
       method: dhcp
   device: /dev/sda       # The target disk to install
   iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso


### PR DESCRIPTION
Related to harvester/harvester-installer#128

Support NIC bonding in harvester config. Mainly turn `networks` array to a map of "NIC name -> NIC configs".

- Remove `install.mgmt_interface`.
- `harvester-mgmt` becomes the mandatory bonding network name.