### PR TITLE
Switch to bonding management network

### DIFF
--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
@@ -10,9 +10,15 @@ os:
   password: {{ settings['harvester_config']['password'] }}
 install:
   mode: create
-  mgmt_interface: {{ settings['harvester_network_config']['cluster'][0]['mgmt_interface'] }}  # The management interface name
   networks:
-    - interface: {{ settings['harvester_network_config']['cluster'][0]['vagrant_interface'] }}
+    harvester-mgmt:
+      interfaces:
+      - name: {{ settings['harvester_network_config']['cluster'][0]['mgmt_interface'] }}  # The management interface name
+      method: dhcp
+    bond0:
+      interfaces:
+      - name: {{ settings['harvester_network_config']['cluster'][0]['vagrant_interface'] }}
+      default_route: true
       method: dhcp
   device: /dev/sda       # The target disk to install
   iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -11,9 +11,15 @@ os:
   password: {{ settings['harvester_config']['password'] }}
 install:
   mode: join
-  mgmt_interface: {{ settings['harvester_network_config']['cluster'][node_number | int]['mgmt_interface'] }}   # The management interface name
   networks:
-    - interface: {{ settings['harvester_network_config']['cluster'][node_number | int]['vagrant_interface'] }}
+    harvester-mgmt:
+      interfaces:
+      - name: {{ settings['harvester_network_config']['cluster'][node_number | int]['mgmt_interface'] }}   # The management interface name
+      method: dhcp
+    bond0:
+      interfaces:
+      - name: {{ settings['harvester_network_config']['cluster'][node_number | int]['vagrant_interface'] }}
+      default_route: true
       method: dhcp
   device: /dev/sda       # The target disk to install
   iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -55,28 +55,28 @@ harvester_network_config:
       mac: 02:00:00:0D:62:E2
       cpu: 4
       memory: 16384
-      disk_size: 60G
+      disk_size: 150G
       vagrant_interface: ens5
       mgmt_interface: ens6
     - ip: 192.168.0.31
       mac: 02:00:00:35:86:92
       cpu: 4
       memory: 8192
-      disk_size: 80G
+      disk_size: 150G
       vagrant_interface: ens5
       mgmt_interface: ens6
     - ip: 192.168.0.32
       mac: 02:00:00:2F:F2:2A
       cpu: 6
       memory: 16384
-      disk_size: 100G
+      disk_size: 150G
       vagrant_interface: ens5
       mgmt_interface: ens6
     - ip: 192.168.0.33
       mac: 02:00:00:A7:E6:FF
       cpu: 4
       memory: 8192
-      disk_size: 80G
+      disk_size: 150G
       vagrant_interface: ens5
       mgmt_interface: ens6
 


### PR DESCRIPTION
The VM disk size is also increased because we need to allocate a 50G
volume (thin-provisioned) for Prometheus data.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>