### PR TITLE
Specify NIC model and virtio disks

### DIFF
--- a/vagrant-pxe-harvester/Vagrantfile
+++ b/vagrant-pxe-harvester/Vagrantfile
@@ -73,6 +73,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         libvirt.boot boot_network
         # NOTE: default to UEFI boot. Comment this out for legacy BIOS.
         libvirt.loader = '/usr/share/qemu/OVMF.fd'
+        libvirt.nic_model_type = 'e1000'
       end
     end
   end

--- a/vagrant-pxe-harvester/Vagrantfile
+++ b/vagrant-pxe-harvester/Vagrantfile
@@ -62,12 +62,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         libvirt.cpu_mode = 'host-passthrough'
         libvirt.memory = @settings['harvester_network_config']['cluster'][node_number].key?('memory') ? @settings['harvester_network_config']['cluster'][node_number]['memory'] : @settings['harvester_node_config']['memory'] 
         libvirt.cpus = @settings['harvester_network_config']['cluster'][node_number].key?('cpu') ? @settings['harvester_network_config']['cluster'][node_number]['cpu'] : @settings['harvester_node_config']['cpu']
-        # NOTE: device must set to 'sda'
         libvirt.storage :file,
           size: @settings['harvester_network_config']['cluster'][node_number].key?('disk_size') ? @settings['harvester_network_config']['cluster'][node_number]['disk_size'] : @settings['harvester_node_config']['disk_size'],
           type: 'qcow2',
-          bus: 'sata',
-          device: 'sda'
+          bus: 'virtio',
+          device: 'vda'
         boot_network = {'network' => 'harvester'}
         libvirt.boot 'hd'
         libvirt.boot boot_network

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
@@ -20,7 +20,7 @@ install:
       - name: {{ settings['harvester_network_config']['cluster'][0]['vagrant_interface'] }}
       default_route: true
       method: dhcp
-  device: /dev/sda       # The target disk to install
+  device: /dev/vda       # The target disk to install
   iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso
 #  tty: ttyS1,115200n8   # For machines without a VGA console
   tty: ttyS0

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -21,7 +21,7 @@ install:
       - name: {{ settings['harvester_network_config']['cluster'][node_number | int]['vagrant_interface'] }}
       default_route: true
       method: dhcp
-  device: /dev/sda       # The target disk to install
+  device: /dev/vda       # The target disk to install
   iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso
 #  tty: ttyS1,115200n8   # For machines without a VGA console
   tty: ttyS0


### PR DESCRIPTION
- Use e1000 NIC model
  - virtio-net doesn't play well with bonding device even there
is only one bonding slave.
- Use virtio disk to improve disk performance.