### PR TITLE
Add offline option

### DIFF
--- a/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
+++ b/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
@@ -13,12 +13,16 @@ log-facility local7;
 subnet {{ settings['harvester_network_config']['dhcp_server']['subnet'] }} netmask {{ settings['harvester_network_config']['dhcp_server']['netmask'] }} {
     range {{ settings['harvester_network_config']['dhcp_server']['range'] }};
     option domain-name-servers {{ settings['harvester_network_config']['dhcp_server']['ip'] }}, 8.8.8.8;
+    {% if settings['harvester_network_config']['offline'] %}
+    option routers {{ settings['harvester_network_config']['dhcp_server']['ip'] }};
+    {% else %}
     option routers {{ settings['harvester_network_config']['dhcp_server']['subnet'][:-1] }}1;
+    {% endif %}
     next-server {{ settings['harvester_network_config']['dhcp_server']['ip'] }};
 
    if exists user-class and option user-class = "iPXE" {
         filename "http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/${net1/mac}";
-    } elsif option arch != 00:00 { 
+    } elsif option arch != 00:00 {
         filename "ipxe/ipxe.efi";
     } else {
         filename "ipxe/undionly.kpxe";

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
@@ -30,3 +30,7 @@ install:
   vip: {{ settings['harvester_network_config']['vip']['ip'] }}
   vip_mode: {{ settings['harvester_network_config']['vip']['mode'] }}
   vip_hw_addr: {{ settings['harvester_network_config']['vip']['mac'] }}
+{% if settings['harvester_network_config']['offline'] %}
+systemSettings:
+  ui-source: bundled
+{% endif %}

--- a/vagrant-pxe-harvester/ansible/roles/proxy/files/default
+++ b/vagrant-pxe-harvester/ansible/roles/proxy/files/default
@@ -1,0 +1,2 @@
+http_access allow all
+http_port 3128

--- a/vagrant-pxe-harvester/ansible/roles/proxy/handlers/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/proxy/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: restart squid
+  systemd:
+    name: squid
+    state: restarted
+    daemon_reload: yes
+    enabled: yes

--- a/vagrant-pxe-harvester/ansible/roles/proxy/tasks/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/proxy/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: install squid
+  apt:
+    update_cache: yes
+    name: squid
+    state: present
+
+- name: configure squid
+  copy:
+    src: default
+    dest: /etc/squid/squid.conf
+  notify: restart squid

--- a/vagrant-pxe-harvester/ansible/setup_pxe_server.yml
+++ b/vagrant-pxe-harvester/ansible/setup_pxe_server.yml
@@ -10,3 +10,5 @@
     - role: http
     - role: ipxe
     - role: harvester
+    - role: proxy
+      when: settings['harvester_network_config']['offline']

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -39,6 +39,10 @@ harvester_cluster_nodes: 3
 # the conflicting one.
 #
 harvester_network_config:
+  # Run as an airgapped environment that only has internet connectivity through an HTTP proxy.
+  # The HTTP proxy runs on DHCP server using port 3128
+  offline: false
+
   dhcp_server:
     ip: 192.168.0.254
     subnet: 192.168.0.0


### PR DESCRIPTION
When `offline` is enabled, external services are not routable by default.
An HTTP proxy is set up in DHCP node(http://192.168.0.254:3128).

This helps to simulate and test an air-gapped environment with an HTTP proxy.