### PR TITLE
feat(vagrant-ipx-harvester): add default ntp servers

### DIFF
--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
@@ -8,6 +8,10 @@ os:
     - {{ ssh_key }}
 {% endfor %}
   password: {{ settings['harvester_config']['password'] }}
+  ntp_servers:
+{% for ntp_server in settings['harvester_config']['ntp_servers'] %}
+    - {{ ntp_server }}
+{% endfor %}
 install:
   mode: create
   networks:

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -9,6 +9,10 @@ os:
     - {{ ssh_key }}
 {% endfor %}
   password: {{ settings['harvester_config']['password'] }}
+  ntp_servers:
+{% for ntp_server in settings['harvester_config']['ntp_servers'] %}
+    - {{ ntp_server }}
+{% endfor %}
 install:
   mode: join
   networks:

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -97,6 +97,11 @@ harvester_config:
   # password to for the `rancher` user to login to the Harvester nodes
   password: p@ssword
 
+  # NTP servers
+  ntp_servers:
+    - 0.suse.pool.ntp.org
+    - 1.suse.pool.ntp.org
+
 #
 # harvester_node_config
 #


### PR DESCRIPTION
issue: https://github.com/harvester/harvester/issues/1535

Check whether we can get `timesync` on each node after installation. Also, please check whether `SystemNTPServers` is same as settings in yml.

```
> timedatectl show-timesync
SystemNTPServers=0.suse.pool.ntp.org 1.suse.pool.ntp.org
FallbackNTPServers=0.suse.pool.ntp.org 1.suse.pool.ntp.org 2.suse.pool.ntp.org 3.suse.pool.ntp.org
ServerName=0.suse.pool.ntp.org
ServerAddress=111.235.248.121
RootDistanceMaxUSec=5s
PollIntervalMinUSec=32s
PollIntervalMaxUSec=34min 8s
PollIntervalUSec=34min 8s
NTPMessage={ Leap=0, Version=4, Mode=4, Stratum=1, Precision=-19, RootDelay=0, RootDispersion=1.525ms, Reference=PPS, OriginateTimestamp=Thu 2021-11-11 07:22:45 UTC, ReceiveTimestamp=Thu 2021-11-11 07:22:45 UTC, TransmitTimestamp=Thu 2021-11-11 07:22:45 UTC, DestinationTimestamp=Thu 2021-11-11 07:22:45 UTC, Ignored=no PacketCount=14, Jitter=6.504ms }
Frequency=-214282
```