### PR TITLE
Update default route

### DIFF
--- a/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
+++ b/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
@@ -13,6 +13,7 @@ log-facility local7;
 subnet {{ settings['harvester_network_config']['dhcp_server']['subnet'] }} netmask {{ settings['harvester_network_config']['dhcp_server']['netmask'] }} {
     range {{ settings['harvester_network_config']['dhcp_server']['range'] }};
     option domain-name-servers {{ settings['harvester_network_config']['dhcp_server']['ip'] }}, 8.8.8.8;
+    option routers {{ settings['harvester_network_config']['dhcp_server']['subnet'][:-1] }}1;
     next-server {{ settings['harvester_network_config']['dhcp_server']['ip'] }};
 
    if exists user-class and option user-class = "iPXE" {

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
@@ -22,7 +22,6 @@ install:
     bond0:
       interfaces:
       - name: {{ settings['harvester_network_config']['cluster'][0]['vagrant_interface'] }}
-      default_route: true
       method: dhcp
   device: /dev/vda       # The target disk to install
   iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -23,7 +23,6 @@ install:
     bond0:
       interfaces:
       - name: {{ settings['harvester_network_config']['cluster'][node_number | int]['vagrant_interface'] }}
-      default_route: true
       method: dhcp
   device: /dev/vda       # The target disk to install
   iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso


### PR DESCRIPTION
Use dev harvester-mgmt via 192.168.0.1

Resolves the following issues:
1. Harvester is broken after enabling vlan network on bond0(https://github.com/harvester/harvester/issues/1541).
2. When enabling vlan network on harvester-mgmt and create a VM using a single vlan NIC. It cannot access the internet because default route is missing.