### PR TITLE
add self-signed CA for https

### DIFF
--- a/vagrant-pxe-harvester/ansible/roles/https/files/https
+++ b/vagrant-pxe-harvester/ansible/roles/https/files/https
@@ -1,0 +1,9 @@
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    include snippets/self-signed.conf;
+    include snippets/ssl-params.conf;
+    location    / {
+        root    /var/www;
+    }
+}

--- a/vagrant-pxe-harvester/ansible/roles/https/files/self-signed.conf
+++ b/vagrant-pxe-harvester/ansible/roles/https/files/self-signed.conf
@@ -1,0 +1,3 @@
+# /etc/nginx/snippets/self-signed.conf
+ssl_certificate /etc/ssl/certs/nginx-selfsigned.crt;
+ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;

--- a/vagrant-pxe-harvester/ansible/roles/https/files/ssl-params.conf
+++ b/vagrant-pxe-harvester/ansible/roles/https/files/ssl-params.conf
@@ -1,0 +1,19 @@
+# /etc/nginx/snippets/ssl-params.conf
+ssl_protocols TLSv1.2;
+ssl_prefer_server_ciphers on;
+ssl_dhparam /etc/nginx/dhparam.pem;
+ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;
+ssl_ecdh_curve secp384r1; # Requires nginx >= 1.1.0
+ssl_session_timeout  10m;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off; # Requires nginx >= 1.5.9
+ssl_stapling on; # Requires nginx >= 1.3.7
+ssl_stapling_verify on; # Requires nginx => 1.3.7
+resolver 8.8.8.8 8.8.4.4 valid=300s;
+resolver_timeout 5s;
+# Disable strict transport security for now. You can uncomment the following
+# line if you understand the implications.
+# add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+add_header X-Frame-Options DENY;
+add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";

--- a/vagrant-pxe-harvester/ansible/roles/https/handlers/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/https/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: restart nginx
+  systemd:
+    name: nginx
+    state: restarted
+    daemon_reload: yes
+    enabled: yes

--- a/vagrant-pxe-harvester/ansible/roles/https/tasks/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/https/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+- name: create config file
+  template:
+    src: "openssl.conf.j2"
+    dest: /var/www/openssl.conf
+
+- name: generate SSL Key
+  command: >
+    openssl req -x509 -nodes -days 365 
+    -config /var/www/openssl.conf
+    -keyout /etc/ssl/private/nginx-selfsigned.key
+    -out /etc/ssl/certs/nginx-selfsigned.crt
+  # To verify IP SANs:
+  # openssl x509 -in /etc/ssl/certs/nginx-selfsigned.crt --noout -text | grep "Subject Alternative" -A5
+
+- name: generate pem for nginx
+  command: openssl dhparam -dsaparam -out /etc/nginx/dhparam.pem 4096
+
+- name: copy configuration
+  copy:
+    src: '{{item}}'
+    dest: '/etc/nginx/snippets/'
+  loop:
+    - self-signed.conf
+    - ssl-params.conf
+
+- name: configure https site
+  copy:
+    src: https
+    dest: /etc/nginx/sites-available
+  notify: restart nginx
+
+- name: enable https site
+  file:
+    src: /etc/nginx/sites-available/https
+    dest: /etc/nginx/sites-enabled/https
+    state: link
+  notify: restart nginx
+
+- name: show CA cert
+  command: cat /etc/ssl/certs/nginx-selfsigned.crt
+  register: command_output
+
+- name: Print to console
+  debug:
+    msg: "{{command_output.stdout}}"

--- a/vagrant-pxe-harvester/ansible/roles/https/templates/openssl.conf.j2
+++ b/vagrant-pxe-harvester/ansible/roles/https/templates/openssl.conf.j2
@@ -1,0 +1,19 @@
+[req]
+default_bits = 4096
+default_md = sha256
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+C = US
+ST = VA
+L = SomeCity
+O = MyCompany
+OU = MyDivision
+CN = {{ settings['harvester_network_config']['dhcp_server']['ip'] }}
+[v3_req]
+keyUsage = keyEncipherment, dataEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+IP.1 = {{ settings['harvester_network_config']['dhcp_server']['ip'] }}

--- a/vagrant-pxe-harvester/ansible/setup_pxe_server.yml
+++ b/vagrant-pxe-harvester/ansible/setup_pxe_server.yml
@@ -12,3 +12,5 @@
     - role: harvester
     - role: proxy
       when: settings['harvester_network_config']['offline']
+    - role: https
+      when: settings['harvester_network_config']['dhcp_server']['https']

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -48,6 +48,7 @@ harvester_network_config:
     subnet: 192.168.0.0
     netmask: 255.255.255.0
     range: 192.168.0.50 192.168.0.130
+    https: false
   # Reserve these IPs for the Harvester cluster. Make sure these are outside
   # the range of DHCP so they don't get served out by the DHCP server
   vip:


### PR DESCRIPTION
add new role **https** to _pxe-server_ with self-signed cert, key will be printed in console.
related feature:  https://github.com/harvester/harvester/issues/1260

preview:
![image](https://user-images.githubusercontent.com/5169694/143480509-0a564eb4-e932-4853-82c7-780d959bb8a9.png)

