### PR TITLE
Promote `include_tasks` instead of `include`

### DIFF
--- a/vagrant-pxe-harvester/ansible/reinstall_harvester_node.yml
+++ b/vagrant-pxe-harvester/ansible/reinstall_harvester_node.yml
@@ -15,7 +15,7 @@
       msg: "{{ figlet_result.stdout }}"
 
   - name: boot Harvester nodes
-    include: boot_harvester_node.yml
+    include_tasks: boot_harvester_node.yml
 
   - name: create "Installation Completed" message
     shell: >

--- a/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
@@ -50,25 +50,25 @@
   with_sequence: "start=1 end={{ end_sequence }}"
 
 - name: download Harvester kernel
-  include: _download_media.yml
+  include_tasks: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_kernel_url'] }}"
     media_filename: "harvester-vmlinuz-amd64"
 
 - name: download Harvester ramdisk
-  include: _download_media.yml
+  include_tasks: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_ramdisk_url'] }}"
     media_filename: "harvester-initrd-amd64"
 
 - name: download Harvester ISO
-  include: _download_media.yml
+  include_tasks: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_iso_url'] }}"
     media_filename: "harvester-amd64.iso"
 
 - name: download Harvester Root FS
-  include: _download_media.yml
+  include_tasks: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_rootfs_url'] }}"
     media_filename: "harvester-rootfs-amd64.squashfs"

--- a/vagrant-pxe-harvester/ansible/setup_harvester.yml
+++ b/vagrant-pxe-harvester/ansible/setup_harvester.yml
@@ -45,7 +45,7 @@
     delay: 30
 
   - name: boot Harvester nodes
-    include: boot_harvester_node.yml
+    include_tasks: boot_harvester_node.yml
     vars:
       node_number: "{{ item }}"
     with_sequence: 0-{{ harvester_cluster_nodes|int - 1 }}


### PR DESCRIPTION
Since there are too many conflicting behaviors and misunderstandings between `include`, `include_tasks`, `import_playbook`, and `import_tasks`, the `include` module is [deprecated in ansible-core v2.12.0](https://github.com/ansible/ansible/blob/stable-2.12/changelogs/CHANGELOG-v2.12.rst#deprecated-features) and will be [removed in v2.16](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_module.html#deprecated). This PR simply updates the dependent Ansible tasks to use `include_tasks`.

Signed-off-by: Zespre Chang <zespre.chang@suse.com>