### PR TITLE
vagrant-pxe: increase CPU cores

### DIFF
--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -58,14 +58,14 @@ harvester_network_config:
   cluster:
     - ip: 192.168.0.30
       mac: 02:00:00:0D:62:E2
-      cpu: 4
+      cpu: 8
       memory: 16384
       disk_size: 150G
       vagrant_interface: ens5
       mgmt_interface: ens6
     - ip: 192.168.0.31
       mac: 02:00:00:35:86:92
-      cpu: 4
+      cpu: 6
       memory: 8192
       disk_size: 150G
       vagrant_interface: ens5
@@ -79,7 +79,7 @@ harvester_network_config:
       mgmt_interface: ens6
     - ip: 192.168.0.33
       mac: 02:00:00:A7:E6:FF
-      cpu: 4
+      cpu: 6
       memory: 8192
       disk_size: 150G
       vagrant_interface: ens5
@@ -114,7 +114,7 @@ harvester_config:
 #
 harvester_node_config:
   # number of CPUs assigned to each node
-  cpu: 4
+  cpu: 6
 
   # memory size for each node, in MBytes
   memory: 8192


### PR DESCRIPTION
We are using more resources now and have started to see out-of-CPU errors.

<img width="1190" alt="Screen Shot 2022-09-30 at 4 24 01 PM" src="https://user-images.githubusercontent.com/1691518/193231809-b07cd205-ae93-4323-8e1e-31569a5715c7.png">


Here is some observation from my new-created 4-node cluster:

Node1:
```
  Resource                       Requests      Limits
  --------                       --------      ------
  cpu                            6210m (77%)   8750m (109%)
  memory                         7216Mi (45%)  9548Mi (59%)
```

Node2:
```
  Resource                       Requests      Limits
  --------                       --------      ------
  cpu                            3850m (64%)   3150m (52%)
  memory                         3630Mi (30%)  2616Mi (21%)
```

Node3:
```
  Resource                       Requests      Limits
  --------                       --------      ------
  cpu                            3490m (58%)   2950m (49%)
  memory                         3182Mi (26%)  2360Mi (19%)
```

Node4:
```
  Resource                       Requests      Limits
  --------                       --------      ------
  cpu                            2895m (48%)   2950m (49%)
  memory                         1540Mi (12%)  2360Mi (19%)
```
Tune the CPU cores up.