### PR TITLE
[v1.1.2] GH kernel and initrd artifacts

### DIFF
--- a/equinix/ipxe-install
+++ b/equinix/ipxe-install
@@ -1,8 +1,9 @@
 #!ipxe
 dhcp
 iflinkwait -t 5000 && echo Detected link on ${ifname} 
-set version master # change to a specific version for production installation
-set base https://releases.rancher.com/harvester/${version}  # ipxe on Equinix currently does not support `https://release.rancher.com`, you can build your own web server or use other methods to download related artifacts.
-kernel ${base}/harvester-${version}-vmlinuz-amd64 ip=dhcp net.ifnames=1 rd.cos.disable rd.noverifyssl root=live:${base}/harvester-${version}-rootfs-amd64.squashfs harvester.install.management_interface.interfaces="hwAddr:${net0/mac}" harvester.install.management_interface.method=dhcp harvester.install.management_interface.bond_options.mode=balance-tlb harvester.install.management_interface.bond_options.miimon=100 console=ttyS1,115200 harvester.install.automatic=true boot_cmd="echo include_ping_test=yes >> /etc/conf.d/net-online" harvester.install.config_url=https://metadata.platformequinix.com/userdata
+set version v1.1.2
+set base https://github.com/harvester/harvester/releases/download/${version}
+set harvesterreleasebase https://releases.rancher.com/harvester/${version}
+kernel ${base}/harvester-${version}-vmlinuz-amd64 ip=dhcp net.ifnames=1 rd.cos.disable rd.noverifyssl root=live:${harvesterreleasebase}/harvester-${version}-rootfs-amd64.squashfs harvester.install.management_interface.interfaces="hwAddr:${net0/mac}" harvester.install.management_interface.method=dhcp harvester.install.management_interface.bond_options.mode=balance-tlb harvester.install.management_interface.bond_options.miimon=100 console=ttyS1,115200 harvester.install.automatic=true boot_cmd="echo include_ping_test=yes >> /etc/conf.d/net-online" harvester.install.config_url=https://metadata.platformequinix.com/userdata
 initrd ${base}/harvester-${version}-initrd-amd64
 boot


### PR DESCRIPTION
PR  changes the install script to use the GH artifact kernel/initrd artifacts available post v1.1.2-rc3 for boot strapping nodes.

Related to: https://github.com/harvester/harvester/issues/2226