### PR TITLE
Increase default Harvester disk size to 250Gi.

### DIFF
--- a/vagrant-pxe-airgap-harvester/settings.yml
+++ b/vagrant-pxe-airgap-harvester/settings.yml
@@ -62,28 +62,28 @@ harvester_network_config:
       mac: 02:00:00:0D:62:E2
       cpu: 8
       memory: 16354
-      disk_size: 200G
+      disk_size: 250G
       vagrant_interface: ens5
       mgmt_interface: ens6
     - ip: 192.168.2.31
       mac: 02:00:00:35:86:92
       cpu: 8
       memory: 16354
-      disk_size: 200G
+      disk_size: 250G
       vagrant_interface: ens5
       mgmt_interface: ens6
     - ip: 192.168.2.32
       mac: 02:00:00:2F:F2:2A
       cpu: 8
       memory: 16354
-      disk_size: 200G
+      disk_size: 250G
       vagrant_interface: ens5
       mgmt_interface: ens6
     - ip: 192.168.2.33
       mac: 02:00:00:A7:E6:FF
       cpu: 8
       memory: 16354
-      disk_size: 200G
+      disk_size: 250G
       vagrant_interface: ens5
       mgmt_interface: ens6
 
@@ -181,4 +181,4 @@ harvester_node_config:
   memory: 16354
 
   # disk size for each node
-  disk_size: 200G
+  disk_size: 250G

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -60,28 +60,28 @@ harvester_network_config:
       mac: 02:00:00:0D:62:E2
       cpu: 8
       memory: 16384
-      disk_size: 200G
+      disk_size: 250G
       vagrant_interface: ens5
       mgmt_interface: ens6
     - ip: 192.168.0.31
       mac: 02:00:00:35:86:92
       cpu: 8
       memory: 8192
-      disk_size: 200G
+      disk_size: 250G
       vagrant_interface: ens5
       mgmt_interface: ens6
     - ip: 192.168.0.32
       mac: 02:00:00:2F:F2:2A
       cpu: 8
       memory: 16384
-      disk_size: 200G
+      disk_size: 250G
       vagrant_interface: ens5
       mgmt_interface: ens6
     - ip: 192.168.0.33
       mac: 02:00:00:A7:E6:FF
       cpu: 8
       memory: 8192
-      disk_size: 200G
+      disk_size: 250G
       vagrant_interface: ens5
       mgmt_interface: ens6
 
@@ -120,4 +120,4 @@ harvester_node_config:
   memory: 8192
 
   # disk size for each node
-  disk_size: 200G
+  disk_size: 250G


### PR DESCRIPTION
**Problem:**
The installation disk minimum requirement already increased to 250Gi, we need to increase disk size in Vagrant config

**Solution:**
Increase default Harvester disk size to 250Gi.

**Related issue:**
https://github.com/harvester/harvester/issues/3842