### PR TITLE
bug: Fix CoreDNS Version & Bump K3s Version

### DIFF
--- a/vagrant-pxe-airgap-harvester/ansible/roles/rancher/tasks/main.yml
+++ b/vagrant-pxe-airgap-harvester/ansible/roles/rancher/tasks/main.yml
@@ -593,6 +593,22 @@
         register: copy_rancher_registries_edit_result
         when: settings.rancher_config.run_single_node_air_gapped_rancher | bool
 
+      - name: ensure k3s server directory exists
+        ansible.builtin.file:
+          path: /var/lib/rancher/k3s/server
+          state: directory
+
+      - name: ensure k3s server manifests directory exists
+        ansible.builtin.file:
+          path: /var/lib/rancher/k3s/server/manifests
+          state: directory
+
+      - name: copy k3s coredns yaml over
+        ansible.builtin.template:
+          src: "coredns.yaml.j2"
+          dest: /var/lib/rancher/k3s/server/manifests/coredns.yaml
+          force: yes
+
       - name: append registries.yaml with edits
         ansible.builtin.shell: |
           cat /etc/rancher/k3s/registries-yaml-edit.yaml >> /etc/rancher/k3s/registries.yaml

--- a/vagrant-pxe-airgap-harvester/ansible/roles/rancher/templates/coredns.yaml.j2
+++ b/vagrant-pxe-airgap-harvester/ansible/roles/rancher/templates/coredns.yaml.j2
@@ -1,0 +1,24 @@
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health
+        ready
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+          pods insecure
+          fallthrough in-addr.arpa ip6.arpa
+        }
+        hosts /etc/coredns/customdomains.db {
+          fallthrough
+
+        }
+        prometheus :9153
+        forward . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+    import /etc/coredns/custom/*.server
+  customdomains.db: |
+    {{ settings.rancher_config.node_harvester_network_ip }} {{ settings.rancher_config.rancher_install_domain }}

--- a/vagrant-pxe-airgap-harvester/settings.yml
+++ b/vagrant-pxe-airgap-harvester/settings.yml
@@ -138,7 +138,7 @@ rancher_config:
   # cert-manager version, for the jetstack.io repo
   cert_manager_version: v1.7.1
   # url escaped k3s version for grabbing k3s
-  k3s_url_escaped_version: v1.23.6%2Bk3s1
+  k3s_url_escaped_version: v1.24.16%2Bk3s1
   # K9s version
   k9s_version: v0.26.3
   # IMPORTANT: "TRUE" RANCHER AIRGAPPED ONLY WORKS WITH 2.6.4 -> 2.6.4-rc-*


### PR DESCRIPTION
* fix coredns for k3s by adding in hostname resolution with customdomains db
* bump k3s version as v2.6.X Rancher and beyond supports v1.24 K3s

Resolves: bug/fix-coredns-for-k3s-and-bump-k3s-version