### PR TITLE
vagrant: pxe_server: apply https role before http

### DIFF
--- a/vagrant-pxe-airgap-harvester/ansible/setup_pxe_server.yml
+++ b/vagrant-pxe-airgap-harvester/ansible/setup_pxe_server.yml
@@ -7,10 +7,10 @@
   roles:
     - role: dhcp
     - role: tftp
+    - role: https
+      when: settings['harvester_network_config']['dhcp_server']['https']
     - role: http
     - role: ipxe
     - role: harvester
     - role: proxy
       when: settings['harvester_network_config']['offline']
-    - role: https
-      when: settings['harvester_network_config']['dhcp_server']['https']

--- a/vagrant-pxe-harvester/ansible/setup_pxe_server.yml
+++ b/vagrant-pxe-harvester/ansible/setup_pxe_server.yml
@@ -7,10 +7,10 @@
   roles:
     - role: dhcp
     - role: tftp
+    - role: https
+      when: settings['harvester_network_config']['dhcp_server']['https']
     - role: http
     - role: ipxe
     - role: harvester
     - role: proxy
       when: settings['harvester_network_config']['offline']
-    - role: https
-      when: settings['harvester_network_config']['dhcp_server']['https']


### PR DESCRIPTION
When harvester_network_config.dhcp_server.https is set to false, ansible gets a bit confused and doesn't run the "restart nginx" handler when deploying the pxe_server.  This can be seen if you manually run `vagrant up pxe_server`:
```
RUNNING HANDLER [http : restart nginx] *****************************************
skipping: [pxe_server] => changed=false
  false_condition: settings['harvester_network_config']['dhcp_server']['https']
  skip_reason: Conditional result was False
```
The problem with this is that if nginx isn't restarted, the newly added default site config isn't read and the "wait for PXE server HTTP port to get ready" task in the Setup Harvester playbook never succeeds.

I think what's happening is that with the http role appearing before the https role, the http role by itself would trigger the restart handler, but this is then overridden somehow by the disabled https role which comes after.  Anyway, the fix is easy: just put the https role before the http role.  If https is turned on, https already includes http and so everything runs through fine (the subsequent http role is ignored as it's already been applied).  If https is turned off, we just get the http role, and the restart works correctly.