### PR TITLE
ansible: add condition for dependencies role

### DIFF
--- a/vagrant-pxe-airgap-harvester/ansible/roles/https/meta/main.yaml
+++ b/vagrant-pxe-airgap-harvester/ansible/roles/https/meta/main.yaml
@@ -1,3 +1,4 @@
 ---
 dependencies:
-  - {role: http}
+  - role: http
+    when: settings['harvester_network_config']['dhcp_server']['https'] | bool == true

--- a/vagrant-pxe-harvester/ansible/roles/https/meta/main.yaml
+++ b/vagrant-pxe-harvester/ansible/roles/https/meta/main.yaml
@@ -1,3 +1,4 @@
 ---
 dependencies:
-  - {role: http}
+  - role: http
+    when: settings['harvester_network_config']['dhcp_server']['https'] | bool == true


### PR DESCRIPTION
    - Make sure we do not overwrite the same handler

I saw a similar CI error on the Jenkins.
That is the same issue mentioned on https://github.com/harvester/ipxe-examples/pull/67.

I thought the `dependencies` role might have some different mechanism.
Adding the condition and changing the loading order would make Jenkins and my local environment happy.

Or could we revert this commit and make `http`/`https` have their restart nginx handler? (That will be simpler.)
commit: https://github.com/harvester/ipxe-examples/commit/1b83fcc8345b4332df05ecc7a2d538ef0da4ce61
Related PR: https://github.com/harvester/ipxe-examples/pull/39
