### PR TITLE
Add DNS support and update include to include_tasks

### DIFF
--- a/vagrant-pxe-airgap-harvester/ansible/prepare_harvester_nodes.yml
+++ b/vagrant-pxe-airgap-harvester/ansible/prepare_harvester_nodes.yml
@@ -19,7 +19,7 @@
 
 
   - name: make Harvester nodes adjusted for rancher
-    include: adjust_harvester_nodes.yml
+    include_tasks: adjust_harvester_nodes.yml
     vars:
       node_number: "{{ item }}"
     with_sequence: 0-{{ harvester_cluster_nodes|int - 1 }}

--- a/vagrant-pxe-airgap-harvester/ansible/reinstall_harvester_node.yml
+++ b/vagrant-pxe-airgap-harvester/ansible/reinstall_harvester_node.yml
@@ -15,7 +15,7 @@
       msg: "{{ figlet_result.stdout }}"
 
   - name: boot Harvester nodes
-    include: boot_harvester_node.yml
+    include_tasks: boot_harvester_node.yml
 
   - name: create "Installation Completed" message
     shell: >

--- a/vagrant-pxe-airgap-harvester/ansible/roles/harvester/tasks/main.yml
+++ b/vagrant-pxe-airgap-harvester/ansible/roles/harvester/tasks/main.yml
@@ -50,25 +50,25 @@
   with_sequence: "start=1 end={{ end_sequence }}"
 
 - name: download Harvester kernel
-  include: _download_media.yml
+  include_tasks: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_kernel_url'] }}"
     media_filename: "harvester-vmlinuz-amd64"
 
 - name: download Harvester ramdisk
-  include: _download_media.yml
+  include_tasks: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_ramdisk_url'] }}"
     media_filename: "harvester-initrd-amd64"
 
 - name: download Harvester ISO
-  include: _download_media.yml
+  include_tasks: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_iso_url'] }}"
     media_filename: "harvester-amd64.iso"
 
 - name: download Harvester Root FS
-  include: _download_media.yml
+  include_tasks: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_rootfs_url'] }}"
     media_filename: "harvester-rootfs-amd64.squashfs"

--- a/vagrant-pxe-airgap-harvester/ansible/setup_harvester.yml
+++ b/vagrant-pxe-airgap-harvester/ansible/setup_harvester.yml
@@ -55,7 +55,7 @@
     ignore_errors: yes
 
   - name: boot Harvester nodes
-    include: boot_harvester_node.yml
+    include_tasks: boot_harvester_node.yml
     vars:
       node_number: "{{ item }}"
     with_sequence: 0-{{ harvester_cluster_nodes|int - 1 }}

--- a/vagrant-pxe-harvester/ansible/reinstall_harvester_node.yml
+++ b/vagrant-pxe-harvester/ansible/reinstall_harvester_node.yml
@@ -15,7 +15,7 @@
       msg: "{{ figlet_result.stdout }}"
 
   - name: boot Harvester nodes
-    include: boot_harvester_node.yml
+    include_tasks: boot_harvester_node.yml
 
   - name: create "Installation Completed" message
     shell: >

--- a/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
+++ b/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
@@ -12,7 +12,7 @@ log-facility local7;
 
 subnet {{ settings['harvester_network_config']['dhcp_server']['subnet'] }} netmask {{ settings['harvester_network_config']['dhcp_server']['netmask'] }} {
     range {{ settings['harvester_network_config']['dhcp_server']['range'] }};
-    option domain-name-servers {{ settings['harvester_network_config']['dhcp_server']['ip'] }}, 8.8.8.8;
+    option domain-name-servers {{ settings['harvester_network_config']['dhcp_server']['dns_server'] }}, {{ settings['harvester_network_config']['dhcp_server']['ip'] }}, 8.8.8.8;
     {% if settings['harvester_network_config']['offline'] %}
     option routers {{ settings['harvester_network_config']['dhcp_server']['ip'] }};
     {% else %}

--- a/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
@@ -50,25 +50,25 @@
   with_sequence: "start=1 end={{ end_sequence }}"
 
 - name: download Harvester kernel
-  include: _download_media.yml
+  include_tasks: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_kernel_url'] }}"
     media_filename: "harvester-vmlinuz-amd64"
 
 - name: download Harvester ramdisk
-  include: _download_media.yml
+  include_tasks: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_ramdisk_url'] }}"
     media_filename: "harvester-initrd-amd64"
 
 - name: download Harvester ISO
-  include: _download_media.yml
+  include_tasks: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_iso_url'] }}"
     media_filename: "harvester-amd64.iso"
 
 - name: download Harvester Root FS
-  include: _download_media.yml
+  include_tasks: _download_media.yml
   vars:
     harvester_media_url: "{{ settings['harvester_rootfs_url'] }}"
     media_filename: "harvester-rootfs-amd64.squashfs"

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
@@ -5,6 +5,11 @@ token: {{ settings['harvester_config']['token'] }}
 os:
   hostname: harvester-node-0
   ssh_authorized_keys:
+  dns_nameservers:
+{% for dns_server in settings['harvester_network_config']['dns_servers'] %}
+  - {{ dns_server }}
+{% endfor %}
+  ssh_authorized_keys:
 {% for ssh_key in settings['harvester_config']['ssh_authorized_keys'] %}
     - {{ ssh_key }}
 {% endfor %}

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
@@ -4,7 +4,6 @@ scheme_version: 1
 token: {{ settings['harvester_config']['token'] }}
 os:
   hostname: harvester-node-0
-  ssh_authorized_keys:
   dns_nameservers:
 {% for dns_server in settings['harvester_network_config']['dns_servers'] %}
   - {{ dns_server }}

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -5,7 +5,6 @@ server_url: https://{{ settings['harvester_network_config']['vip']['ip'] }}:443
 token: {{ settings['harvester_config']['token'] }}
 os:
   hostname: harvester-node-{{ node_number }}
-  ssh_authorized_keys:
   dns_nameservers:
 {% for dns_server in settings['harvester_network_config']['dns_servers'] %}
   - {{ dns_server }}

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -6,6 +6,11 @@ token: {{ settings['harvester_config']['token'] }}
 os:
   hostname: harvester-node-{{ node_number }}
   ssh_authorized_keys:
+  dns_nameservers:
+{% for dns_server in settings['harvester_network_config']['dns_servers'] %}
+  - {{ dns_server }}
+{% endfor %}
+  ssh_authorized_keys:
 {% for ssh_key in settings['harvester_config']['ssh_authorized_keys'] %}
     - {{ ssh_key }}
 {% endfor %}

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -49,7 +49,12 @@ harvester_network_config:
     netmask: 255.255.255.0
     range: 192.168.0.50 192.168.0.130
     https: false
-
+    #  Change this to a custom DNS server if you need one for your DHCP scope
+    dns_server: 4.4.2.2
+  dns_servers:
+  # This is a list of DNS servers that will be included in your Harvester OS config
+    - 192.168.0.254
+    - 8.8.8.8
   # Reserve these IPs for the Harvester cluster. Make sure these are outside
   # the range of DHCP so they don't get served out by the DHCP server
   vip:


### PR DESCRIPTION
This PR creates a new entry for both DNS on the harvester node as well as defining it in the DHCP scope for the virtual cluster. I also updated the `include` to `include_tasks` in ansible since those were deprecated.