### PR TITLE
vagrant: support etcd only nodes

### DIFF
--- a/vagrant-pxe-airgap-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-airgap-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -15,6 +15,9 @@ os:
 {% endfor %}
 install:
   mode: join
+{% if settings['harvester_network_config']['cluster'][node_number |int]['etcd_only'] %}
+  role: etcd
+{% endif %}
   networks:
     harvester-mgmt:
       interfaces:

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -20,6 +20,9 @@ os:
 {% endfor %}
 install:
   mode: join
+{% if settings['harvester_network_config']['cluster'][node_number |int]['etcd_only'] %}
+  role: etcd
+{% endif %}
   management_interface:
     interfaces:
     - name: {{ settings['harvester_network_config']['cluster'][node_number | int]['mgmt_interface'] }}  # The management interface name

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -69,6 +69,7 @@ harvester_network_config:
       disk_size: 500G
       vagrant_interface: ens5
       mgmt_interface: ens6
+      etcd_only: false
     - ip: 192.168.0.31
       mac: 02:00:00:35:86:92
       cpu: 8
@@ -76,6 +77,7 @@ harvester_network_config:
       disk_size: 500G
       vagrant_interface: ens5
       mgmt_interface: ens6
+      etcd_only: false
     - ip: 192.168.0.32
       mac: 02:00:00:2F:F2:2A
       cpu: 8
@@ -83,6 +85,7 @@ harvester_network_config:
       disk_size: 500G
       vagrant_interface: ens5
       mgmt_interface: ens6
+      etcd_only: false
     - ip: 192.168.0.33
       mac: 02:00:00:A7:E6:FF
       cpu: 8
@@ -90,6 +93,7 @@ harvester_network_config:
       disk_size: 500G
       vagrant_interface: ens5
       mgmt_interface: ens6
+      etcd_only: false
 
 #
 # harvester_config


### PR DESCRIPTION
    - now we can change the `etcd_only: true` to make this node
      an etcd-only node. (This is for witness feature)