### PR TITLE
Fix incomplete DHCP mapping

### DIFF
--- a/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
+++ b/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
@@ -34,7 +34,7 @@ host harvest_vip {
     fixed-address {{ settings['harvester_network_config']['vip']['ip'] }};
 }
 
-{% for node_number in range(settings['harvester_cluster_nodes']) %}
+{% for node_number in range(settings['harvester_network_config']['cluster'] | length) %}
 host harvest_node_{{ node_number }} {
     hardware ethernet {{ settings['harvester_network_config']['cluster'][node_number]['mac'] }};
     fixed-address {{ settings['harvester_network_config']['cluster'][node_number]['ip'] }};

--- a/vagrant-pxe-harvester/reinstall_harvester_node.sh
+++ b/vagrant-pxe-harvester/reinstall_harvester_node.sh
@@ -19,12 +19,13 @@ fi
 
 NODE_NUMBER=$1
 NODE_NAME="harvester-node-${NODE_NUMBER}"
+TOTAL_NODES_STR=`grep harvester_cluster_nodes: settings.yml`
 
 # check to make sure the node has not been created
-NOT_CREATED=`vagrant status ${NODE_NAME} | grep "^${NODE_NAME}" | grep "not created" || true`
+NOT_CREATED=`vagrant status | grep "^${NODE_NAME}" | grep "not created" || true`
 
 if [ "${NOT_CREATED}" == "" ] ; then
-  echo "Harvester node ${NODE_NAME} already created."
+  echo "${NODE_NAME} already created or exceeds defined size (${TOTAL_NODES_STR})."
   exit 1
 fi
 


### PR DESCRIPTION
## Changes
1. Preparing complete DHCP mapping
   * Fix problem in previous PR #69  that adding node will have wrong address due to incomplete dhcp mapping.


## Verification
1. DHCP server contains complete nodes info :ballot_box_with_check: 
    ```
    vagrant@pxe-server:~$ cat /etc/dhcp/dhcpd.conf 
    ...
    
    host harvest_vip {
        hardware ethernet 02:00:00:03:3D:61;
        fixed-address 192.168.0.131;
    }
    
    host harvest_node_0 {
        hardware ethernet 02:00:00:0D:62:E2;
        fixed-address 192.168.0.30;
        server-name "harvester-node-0";
    }
    
    host harvest_node_1 {
        hardware ethernet 02:00:00:35:86:92;
        fixed-address 192.168.0.31;
        server-name "harvester-node-1";
    }
    
    host harvest_node_2 {
        hardware ethernet 02:00:00:2F:F2:2A;
        fixed-address 192.168.0.32;
        server-name "harvester-node-2";
    }
    
    host harvest_node_3 {
        hardware ethernet 02:00:00:A7:E6:FF;
        fixed-address 192.168.0.33;
        server-name "harvester-node-3";
    }
    
    ```

2. Setup 2 nodes cluster
   * <details>
       <summary> <b>node0</b> and <b>node1</b> (<code>harvester_cluster_nodes: 2</code>) :ballot_box_with_check: 
       </summary>
 
       ```
       $ grep _nodes: settings.yml 
       harvester_cluster_nodes: 2
       ```
       ![image](https://github.com/harvester/ipxe-examples/assets/2773781/54190777-07e3-4332-9cca-89a434de0899)
     </details>

   * <details>
       <summary> Forbidden to reinstall an existing node :ballot_box_with_check: 
       </summary>
 
       ```
       $ ./reinstall_harvester_node.sh 1
       harvester-node-1 already created or exceeds defined size (harvester_cluster_nodes: 2).
       ```
     </details>


4. Adding nodes    
   * <details>
       <summary> Forbidden to add node over <code>harvester_cluster_nodes</code> value :ballot_box_with_check: 
       </summary>
 
       ```
       $ ./reinstall_harvester_node.sh 2
       harvester-node-2 already created or exceeds defined size (harvester_cluster_nodes: 2).
       ```
     </details>

   * <details>
       <summary> Change <code>harvester_cluster_nodes</code> to <code>4</code>
       </summary>
 
       ```
       $ grep _nodes: settings.yml 
       harvester_cluster_nodes: 4
       ```
     </details>

   * <details>
       <summary> Add <b>node2</b> :ballot_box_with_check: 
       </summary>
 
       `./reinstall_harvester_node.sh 2`
       ![image](https://github.com/harvester/ipxe-examples/assets/2773781/54cc22e9-c5ca-4058-a60b-a1e0032e3147)
       
       ```
       $ ./reinstall_harvester_node.sh 2
       harvester-node-2 already created or exceeds defined size (harvester_cluster_nodes: 4).
       ```
     </details>

   * <details>
       <summary> Add <b>node3</b> :ballot_box_with_check: 
       </summary>
 
       `./reinstall_harvester_node.sh 3`
    ![image](https://github.com/harvester/ipxe-examples/assets/2773781/e7053256-708c-4d62-aa61-85130d96768c)
    
       ```
       $ ./reinstall_harvester_node.sh 3
       harvester-node-3 already created or exceeds defined size (harvester_cluster_nodes: 4).
       ```
     </details>
