### PR TITLE
fix: Adjust Playbook To Run On Newer Ansible

### DIFF
--- a/vagrant-pxe-harvester/ansible/setup_harvester.yml
+++ b/vagrant-pxe-harvester/ansible/setup_harvester.yml
@@ -35,7 +35,7 @@
     delay: 30
 
   - name: boot Harvester nodes
-    include: boot_harvester_node.yml
+    ansible.builtin.include_tasks: boot_harvester_node.yml
     vars:
       node_number: "{{ item }}"
     with_sequence: 0-{{ harvester_cluster_nodes|int - 1 }}


### PR DESCRIPTION
* currently the Ansible fails on ansible-core 2.16.2 (Dec, 2023 release) or anything newer due to the deprecation of `include`, this has been adjusted

Resolves: https://github.com/harvester/tests/issues/1098