### PR TITLE
ansible: use include_tasks instead built.include

### DIFF
--- a/vagrant-pxe-harvester/ansible/setup_harvester.yml
+++ b/vagrant-pxe-harvester/ansible/setup_harvester.yml
@@ -35,7 +35,7 @@
     delay: 30
 
   - name: boot Harvester nodes
-    include: boot_harvester_node.yml
+    include_tasks: boot_harvester_node.yml
     vars:
       node_number: "{{ item }}"
     with_sequence: 0-{{ harvester_cluster_nodes|int - 1 }}


### PR DESCRIPTION
To fix the following error:
```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```