### PR TITLE
Use 1.1.1.1 as dns_server, instead of 4.4.2.2

### DIFF
--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -50,7 +50,7 @@ harvester_network_config:
     range: 192.168.0.50 192.168.0.130
     https: false
     #  Change this to a custom DNS server if you need one for your DHCP scope
-    dns_server: 4.4.2.2
+    dns_server: 1.1.1.1
 
   dns_servers:
   # This is a list of DNS servers that will be included in your Harvester OS config


### PR DESCRIPTION
The DNS server 4.4.2.2 actually doesn't exist.  This causes problems, notably when deploying RKE2 clusters on openSUSE VMs in Harvester, because you end up with the following in your VM's /etc/resolv.conf:

```
nameserver 4.4.2.2
nameserver 192.168.0.254
nameserver 8.8.8.8
```

The resolver will try these servers in order when doing DNS lookups. Because 4.4.2.2 doesn't exist, and 192.168.0.254 also doesn't respond to DNS queries (it's only a DHCP server...) it means we can hit timeouts when rancher-system-agent tries to pull images, e.g.:

```
Jun 05 03:41:54 rke2-v12713-pool1-996bce2c-5nds2 rancher-system-agent[2797]: time="2024-06-05T03:41:54Z" level=info msg="Pulling image index.docker.io/rancher/system-agent-installer-rke2:v1.27.13-rke2r1"
Jun 05 03:42:23 rke2-v12713-pool1-996bce2c-5nds2 rancher-system-agent[2797]: time="2024-06-05T03:42:23Z" level=warning msg="Failed to get image from endpoint: Get \"https://index.docker.io/v2/\": dial tcp: lookup index.docker.io: i/o timeout"
Jun 05 03:42:23 rke2-v12713-pool1-996bce2c-5nds2 rancher-system-agent[2797]: time="2024-06-05T03:42:23Z" level=error msg="error while staging: all endpoints failed: Get \"https://index.docker.io/v2/\": dial tcp: lookup index.docker.io: i/o timeout: failed to get image index.docker.io/rancher/system-agent-installer-rke2:v1.27.13-rke2r1"
```

This completely breaks RKE2 cluster deployment, at least on openSUSE VMs.  Ubuntu apparently works regardless - maybe there's something different about the resolver on Ubuntu.  Anyway, the fix is to replace 4.4.2.2 with a DNS server that actually exists.  I've used 1.1.1.1, because Cloudflare advertise it as a fast, public DNS server (https://www.cloudflare.com/learning/dns/what-is-1.1.1.1/).

I suppose it's possible 4.4.2.2 was originally a typo of 4.2.2.2, which _does_ exist, but is not necessarily recommended for general use (see https://blog.travisflix.com/4-2-2-2-story-behind-dns-legend/).

Related issue: https://github.com/harvester/harvester/issues/5965