### PR TITLE
Specify Rancher's K3s platform by K3S_CHANNEL

### DIFF
--- a/vagrant-pxe-harvester/Vagrantfile
+++ b/vagrant-pxe-harvester/Vagrantfile
@@ -23,7 +23,7 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = "libvirt"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  # continerd is taking more than 60 seconds to shutdown in SUSE platforms
+  # containerd is taking more than 60 seconds to shutdown in SUSE platforms
   # so increase the timeout to 120 seconds
   config.vm.graceful_halt_timeout = 120
   
@@ -59,7 +59,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       harvester_node.vm.hostname = "harvester-node-#{node_number}"
       harvester_node.vm.network 'private_network',
         libvirt__network_name: 'harvester',
-        mac: @settings['harvester_network_config']['cluster'][node_number]['mac']
+        mac: @settings['harvester_network_config']['cluster'][node_number]['mgmt_mac']
 
       harvester_node.vm.provider :libvirt do |libvirt|
         libvirt.cpu_mode = 'host-passthrough'

--- a/vagrant-pxe-harvester/ansible.cfg
+++ b/vagrant-pxe-harvester/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 stdout_callback = yaml
 interpreter_python = auto_silent
+display_skipped_hosts = False

--- a/vagrant-pxe-harvester/ansible/reinstall_rancher.yml
+++ b/vagrant-pxe-harvester/ansible/reinstall_rancher.yml
@@ -32,4 +32,4 @@
       register: http_resp
       until: http_resp.status == 200
       retries: 10
-      delay: 30
+      delay: 60

--- a/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
+++ b/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
@@ -36,7 +36,7 @@ host harvest_vip {
 
 {% for node_number in range(settings['harvester_network_config']['cluster'] | length) %}
 host harvest_node_{{ node_number }} {
-    hardware ethernet {{ settings['harvester_network_config']['cluster'][node_number]['mac'] }};
+    hardware ethernet {{ settings['harvester_network_config']['cluster'][node_number]['mgmt_mac'] }};
     fixed-address {{ settings['harvester_network_config']['cluster'][node_number]['ip'] }};
     server-name "harvester-node-{{ node_number }}";
 }

--- a/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
@@ -15,7 +15,7 @@
 # make sure end sequence is at least 1 even if we have only one Harvester node
 - name: set node sequence fact
   set_fact:
-    end_sequence: "{{ settings['harvester_network_config']['cluster'] | length - 1}}"
+    end_sequence: "{{ settings['harvester_network_config']['cluster'] | length - 1 }}"
 
 - name: copy config-join.yaml
   template:
@@ -36,17 +36,17 @@
 - name: create boot entry for the first node
   template:
     src: ipxe-create.j2
-    dest: /var/www/harvester/{{ settings['harvester_network_config']['cluster'][0]['mac']|lower }}
+    dest: /var/www/harvester/{{ settings['harvester_network_config']['cluster'][0]['mgmt_mac']|lower }}
   vars:
-    boot_interface: "{{ settings['harvester_network_config']['cluster'][0]['vagrant_interface'] }}"
+    boot_interface: "{{ settings['harvester_network_config']['cluster'][0]['vagrant_nic'] }}"
 
 - name: create boot entry for the cluster members
   template:
     src: ipxe-join.j2
-    dest: /var/www/harvester/{{ settings['harvester_network_config']['cluster'][item|int]['mac']|lower }}
+    dest: /var/www/harvester/{{ settings['harvester_network_config']['cluster'][item|int]['mgmt_mac']|lower }}
   vars:
     node_number: "{{ item }}"
-    boot_interface: "{{ settings['harvester_network_config']['cluster'][item|int]['vagrant_interface'] }}"
+    boot_interface: "{{ settings['harvester_network_config']['cluster'][item|int]['vagrant_nic'] }}"
   with_sequence: "start=1 end={{ end_sequence }}"
 
 - name: download Harvester kernel

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
@@ -17,9 +17,9 @@ os:
 {% for ntp_server in settings['harvester_config']['ntp_servers'] %}
     - {{ ntp_server }}
 {% endfor %}
-{% if settings['harvester_network_config']['sftp'] %}
+{% if settings['harvester_config']['sftp'] %}
   sshd:
-    sftp: {{ settings['harvester_network_config']['sftp'] }}
+    sftp: {{ settings['harvester_config']['sftp'] }}
 {% endif %}
 install:
   mode: create

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
@@ -28,7 +28,7 @@ install:
 {% endif %}
   management_interface:
     interfaces:
-    - name: {{ settings['harvester_network_config']['cluster'][0]['mgmt_interface'] }}  # The management interface name
+    - name: {{ settings['harvester_network_config']['cluster'][0]['mgmt_nic'] }}
     method: dhcp
   device: /dev/vda       # The target disk to install
   iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -29,7 +29,7 @@ install:
 {% endif %}
   management_interface:
     interfaces:
-    - name: {{ settings['harvester_network_config']['cluster'][node_number | int]['mgmt_interface'] }}  # The management interface name
+    - name: {{ settings['harvester_network_config']['cluster'][node_number | int]['mgmt_nic'] }}
     method: dhcp
   device: /dev/vda       # The target disk to install
   iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -18,9 +18,9 @@ os:
 {% for ntp_server in settings['harvester_config']['ntp_servers'] %}
     - {{ ntp_server }}
 {% endfor %}
-{% if settings['harvester_network_config']['sftp'] %}
+{% if settings['harvester_config']['sftp'] %}
   sshd:
-    sftp: {{ settings['harvester_network_config']['sftp'] }}
+    sftp: {{ settings['harvester_config']['sftp'] }}
 {% endif %}
 install:
   mode: join

--- a/vagrant-pxe-harvester/ansible/setup_harvester.yml
+++ b/vagrant-pxe-harvester/ansible/setup_harvester.yml
@@ -54,7 +54,7 @@
     register: http_resp
     until: http_resp.status == 200
     retries: 10
-    delay: 30
+    delay: 60
     when: rancher_config.enabled
 
   - debug:

--- a/vagrant-pxe-harvester/ansible/setup_rancher.yml
+++ b/vagrant-pxe-harvester/ansible/setup_rancher.yml
@@ -6,12 +6,14 @@
   hosts: all
   become: yes
   any_errors_fatal: true
+  vars:
+    kubeconfig: /etc/rancher/k3s/k3s.yaml
   
   tasks:
     - name: setup k3s 
       shell: curl -sfL https://get.k3s.io | sh -
       environment:
-        INSTALL_K3S_VERSION: "{{ settings.rancher_config.kubernetes.version }}"
+        INSTALL_K3S_CHANNEL: "{{ settings.rancher_config.k3s_channel }}"
 
     - name: setup helm
       shell: curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
@@ -27,9 +29,9 @@
         helm install cert-manager jetstack/cert-manager
         --namespace cert-manager
         --create-namespace
-        --set installCRDs=true
+        --set crds.enabled=true
       environment:
-        KUBECONFIG: "{{ settings.rancher_config.kubernetes.config }}"
+        KUBECONFIG: "{{ kubeconfig }}"
 
     - name: setup rancher
       shell: >
@@ -41,4 +43,4 @@
         --set bootstrapPassword={{ settings.rancher_config.password }}
         --set hostname={{ settings.rancher_config.hostname }}
       environment:
-        KUBECONFIG: "{{ settings.rancher_config.kubernetes.config }}"
+        KUBECONFIG: "{{ kubeconfig }}"

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -28,8 +28,7 @@ harvester_cluster_nodes: 3
 # network_config
 #
 # Harvester network configurations. Make sure the cluster IPs are on the same
-# subnet as the DHCP server. Pre-assign the IPs and MACs for the Harvester
-# nodes.
+# subnet as the DHCP server. Pre-assign the IPs and MACs for the Harvester nodes.
 #
 # NOTE: Random MAC addresses are generated with the following command:
 # printf '02:00:00:%02X:%02X:%02X\n' $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256))
@@ -131,25 +130,19 @@ harvester_node_config:
 #
 # rancher_config
 #
-# Rancher setup on an independent node.
-#
-# Support Matrix: https://www.suse.com/suse-rancher/support-matrix/all-supported-versions
-# K3s Release: https://docs.k3s.io/release-notes/v1.28.X
+# Rancher setup on K3s cluster. Refer supported versions on
+# https://www.suse.com/suse-rancher/support-matrix/all-supported-versions
 #
 rancher_config:
   enabled: false
-  version: v2.8.5
+
+  version: v2.9.3
+  k3s_channel: v1.30
   repo: https://releases.rancher.com/server-charts/latest
 
-  kubernetes:
-    version: v1.28.11+k3s1
-    config: /etc/rancher/k3s/k3s.yaml
-
-  # IP should be out of harvester_network_config.dhcp_server.range and does not
-  # conflict with other static IPs (e.g. Harvester).
+  # Reserved IP for Rancher. Do not conflict with DHCP range and other reserved IPs.
   ip: 192.168.0.141
   hostname: rancher.192.168.0.141.sslip.io
   password: password1234
-
   cpu: 2
   memory: 4096

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -67,37 +67,40 @@ harvester_network_config:
   cluster:
     # role: default, management, witness or worker
     - ip: 192.168.0.30
-      mac: 02:00:00:0D:62:E2
+      role: default
       cpu: 8
       memory: 16384
       disk_size: 500G
-      vagrant_interface: ens5
-      mgmt_interface: ens6
-      role: default
+      vagrant_nic: ens5
+      mgmt_nic: ens6
+      mgmt_mac: 02:00:00:0D:62:E2
+
     - ip: 192.168.0.31
-      mac: 02:00:00:35:86:92
+      role: default
       cpu: 8
       memory: 16384
       disk_size: 500G
-      vagrant_interface: ens5
-      mgmt_interface: ens6
-      role: default
+      vagrant_nic: ens5
+      mgmt_nic: ens6
+      mgmt_mac: 02:00:00:35:86:92
+
     - ip: 192.168.0.32
-      mac: 02:00:00:2F:F2:2A
+      role: default
       cpu: 8
       memory: 16384
       disk_size: 500G
-      vagrant_interface: ens5
-      mgmt_interface: ens6
-      role: default
+      vagrant_nic: ens5
+      mgmt_nic: ens6
+      mgmt_mac: 02:00:00:2F:F2:2A
+
     - ip: 192.168.0.33
-      mac: 02:00:00:A7:E6:FF
+      role: default
       cpu: 8
       memory: 8192
       disk_size: 500G
-      vagrant_interface: ens5
-      mgmt_interface: ens6
-      role: default
+      vagrant_nic: ens5
+      mgmt_nic: ens6
+      mgmt_mac: 02:00:00:A7:E6:FF
 
 #
 # harvester_config
@@ -127,13 +130,8 @@ harvester_config:
 # Harvester node-specific configurations.
 #
 harvester_node_config:
-  # number of CPUs assigned to each node
   cpu: 8
-
-  # memory size for each node, in MBytes
   memory: 8192
-
-  # disk size for each node
   disk_size: 500G
 
 #

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -7,11 +7,11 @@
 #
 # harvester_iso_url
 # harvester_kernel_url
-# harvester_initrd_url
+# harvester_ramdisk_url
+# harvester_rootfs_url
 #
-# Harvester media to install. The URL scheme can be either 'http', 'https', or
-# 'file'. If the URL scheme is 'file', the given media will be copied from the
-# local file system instead of downloading from a remote location.
+# Harvester media location. URL schema can be either 'http', 'https' or 'file'
+#
 harvester_iso_url: https://releases.rancher.com/harvester/master/harvester-master-amd64.iso
 harvester_kernel_url: https://releases.rancher.com/harvester/master/harvester-master-vmlinuz-amd64
 harvester_ramdisk_url: https://releases.rancher.com/harvester/master/harvester-master-initrd-amd64
@@ -33,10 +33,7 @@ harvester_cluster_nodes: 3
 #
 # NOTE: Random MAC addresses are generated with the following command:
 # printf '02:00:00:%02X:%02X:%02X\n' $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256))
-# Thanks to https://stackoverflow.com/questions/8484877/mac-address-generator-in-python
-# If any of the generated MAC addresses is in conflict with an existing one in
-# your environment, please use the above command to regenerate and replace
-# the conflicting one.
+# Ref. https://stackoverflow.com/questions/8484877/mac-address-generator-in-python
 #
 harvester_network_config:
   # Run as an airgapped environment that only has internet connectivity through an HTTP proxy.
@@ -49,21 +46,22 @@ harvester_network_config:
     netmask: 255.255.255.0
     range: 192.168.0.50 192.168.0.130
     https: false
-    #  Change this to a custom DNS server if you need one for your DHCP scope
+    # Custom DNS to prepend on DHCP server's domain-name-servers option
     dns_server: 1.1.1.1
 
+  # DNS for Harvester OS
   dns_servers:
-  # This is a list of DNS servers that will be included in your Harvester OS config
     - 192.168.0.254
     - 8.8.8.8
 
-  # Reserve these IPs for the Harvester cluster. Make sure these are outside
-  # the range of DHCP so they don't get served out by the DHCP server
+  # Subsystem used to configure the sshd, refer to harvester configuration 'os.sshd.sftp'.
+  sftp: true
+
+  # Reserved following IPs for Harvester cluster. Make sure they are outside the DHCP range.
   vip:
     ip: 192.168.0.131
     mode: DHCP
     mac: 02:00:00:03:3D:61
-  sftp: true
   cluster:
     # role: default, management, witness or worker
     - ip: 192.168.0.30
@@ -74,7 +72,6 @@ harvester_network_config:
       vagrant_nic: ens5
       mgmt_nic: ens6
       mgmt_mac: 02:00:00:0D:62:E2
-
     - ip: 192.168.0.31
       role: default
       cpu: 8
@@ -83,7 +80,6 @@ harvester_network_config:
       vagrant_nic: ens5
       mgmt_nic: ens6
       mgmt_mac: 02:00:00:35:86:92
-
     - ip: 192.168.0.32
       role: default
       cpu: 8
@@ -92,7 +88,6 @@ harvester_network_config:
       vagrant_nic: ens5
       mgmt_nic: ens6
       mgmt_mac: 02:00:00:2F:F2:2A
-
     - ip: 192.168.0.33
       role: default
       cpu: 8
@@ -113,10 +108,9 @@ harvester_config:
 
   # Public keys to add to authorized_keys of each node.
   ssh_authorized_keys:
-    # Vagrant default unsecured SSH public key
     - ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key
 
-  # password to for the `rancher` user to login to the Harvester nodes via SSH
+  # password for the user 'rancher' to SSH Harvester nodes
   password: p@ssword
 
   # NTP servers

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -10,7 +10,7 @@
 # harvester_ramdisk_url
 # harvester_rootfs_url
 #
-# Harvester media location. URL schema can be either 'http', 'https' or 'file'
+# Harvester media location. URL schema can be either 'http', 'https' or 'file'.
 #
 harvester_iso_url: https://releases.rancher.com/harvester/master/harvester-master-amd64.iso
 harvester_kernel_url: https://releases.rancher.com/harvester/master/harvester-master-vmlinuz-amd64
@@ -20,15 +20,14 @@ harvester_rootfs_url: https://releases.rancher.com/harvester/master/harvester-ma
 #
 # harvester_cluster_nodes
 #
-# NOTE: keep in mind that you need at least 3 nodes to make a cluster
+# Current Harvester cluster size. Keep in mind that you need at least 3 nodes to make a cluster.
 #
 harvester_cluster_nodes: 3
 
 #
 # network_config
 #
-# Harvester network configurations. Make sure the cluster IPs are on the same
-# subnet as the DHCP server. Pre-assign the IPs and MACs for the Harvester nodes.
+# Harvester network configurations.
 #
 # NOTE: Random MAC addresses are generated with the following command:
 # printf '02:00:00:%02X:%02X:%02X\n' $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256))
@@ -45,18 +44,15 @@ harvester_network_config:
     netmask: 255.255.255.0
     range: 192.168.0.50 192.168.0.130
     https: false
-    # Custom DNS to prepend on DHCP server's domain-name-servers option
+    # Change this to a custom DNS server if you need one for your DHCP scope
     dns_server: 1.1.1.1
 
-  # DNS for Harvester OS
   dns_servers:
+  # This is a list of DNS servers that will be included in your Harvester OS config
     - 192.168.0.254
     - 8.8.8.8
 
-  # Subsystem used to configure the sshd, refer to harvester configuration 'os.sshd.sftp'.
-  sftp: true
-
-  # Reserved following IPs for Harvester cluster. Make sure they are outside the DHCP range.
+  # Reserved IPs should be in DHCP subnet BUT outside DHCP range.
   vip:
     ip: 192.168.0.131
     mode: DHCP
@@ -102,20 +98,20 @@ harvester_network_config:
 # Harvester system configurations.
 #
 harvester_config:
-  # static token for cluster authentication
+  # static token for cluster join authentication
   token: token
 
-  # Public keys to add to authorized_keys of each node.
+  # for user 'rancher' to SSH Harvester nodes
+  password: p@ssword
   ssh_authorized_keys:
     - ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key
 
-  # password for the user 'rancher' to SSH Harvester nodes
-  password: p@ssword
-
-  # NTP servers
   ntp_servers:
     - 0.suse.pool.ntp.org
     - 1.suse.pool.ntp.org
+
+  # subsystem to configure sshd, refer to harvester configuration 'os.sshd.sftp'.
+  sftp: true
 
 #
 # harvester_node_config


### PR DESCRIPTION
## Changes
1. Specify K3s version for Rancher by K3S channel instead of full verison
   * In practice, we care about the K8s major and minor verion (e.g. `v1.29`, `v1.30`...) but seldom the patch version as it rolls quick.
   * For convenient usage, leveraging `INSTALL_K3S_CHANNEL` env. variable instead of full `INSTALL_K3S_VERSION`.
   * Reference
     * https://docs.k3s.io/upgrades/manual
     * https://github.com/k3s-io/k3s/blob/master/channel.yaml
  
1. Refactors
   * Rename `vagrant_interface` to `vagrant_nic`
   * Rename `mgmt_interface`/`mac` to `mgmt_nic`/`mgmt_mac`
   * Move `sftp` from `harvester_network_config` to `harvester_config`

## Verification
Issue harvester/harvester/issues/6972 was verified in the env. setup by this enhancement.



