### PR TITLE
Fix QEMU ovmf path and remove out-of-date rancher set-string

### DIFF
--- a/vagrant-pxe-harvester/Vagrantfile
+++ b/vagrant-pxe-harvester/Vagrantfile
@@ -74,8 +74,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         libvirt.boot 'hd'
         libvirt.boot boot_network
         # NOTE: default to UEFI boot. Comment this out for legacy BIOS.
-        libvirt.loader = '/usr/share/qemu/OVMF.fd'
-        libvirt.nic_model_type = 'e1000'
+        libvirt.loader = '/usr/share/qemu/ovmf-x86_64.bin'
+        libvirt.nic_model_type = 'virtio'
       end
     end
   end

--- a/vagrant-pxe-harvester/ansible/setup_rancher.yml
+++ b/vagrant-pxe-harvester/ansible/setup_rancher.yml
@@ -39,7 +39,6 @@
         --namespace cattle-system
         --create-namespace
         --version {{ settings.rancher_config.version }}
-        --set-string ingress.extraAnnotations.'nginx\.ingress\.kubernetes\.io/http2-push-preload'=false
         --set bootstrapPassword={{ settings.rancher_config.password }}
         --set hostname={{ settings.rancher_config.hostname }}
       environment:

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -126,14 +126,14 @@ harvester_node_config:
 #
 # rancher_config
 #
-# Rancher setup on K3s cluster. Refer supported versions on
-# https://www.suse.com/suse-rancher/support-matrix/all-supported-versions
-#
+# Rancher setup on K3s cluster.
+# Refer support matrix on https://ranchermanager.docs.rancher.com/versions
+# 
 rancher_config:
   enabled: false
 
-  version: v2.9.3
-  k3s_channel: v1.30
+  version: v2.11.0
+  k3s_channel: v1.32
   repo: https://releases.rancher.com/server-charts/latest
 
   # Reserved IP for Rancher. Do not conflict with DHCP range and other reserved IPs.


### PR DESCRIPTION
#### Problem:
1. QEMU ovmf is not correct.
2. Rancher has new support matrix webpage
3. A Rancher `set-string` does not need to newer versions

#### Solution:
1. Update ovmf to correct path
2. Update Rancher support matrix link
3. Drop old Rancher `set-string` 

#### Related Issue(s):
n/a

#### Test plan:
Cluster can be provisioned correctly

#### Additional documentation or context
