### PR TITLE
enable guest agent and ssh

### DIFF
--- a/vagrant-pxe-harvester/Vagrantfile
+++ b/vagrant-pxe-harvester/Vagrantfile
@@ -61,7 +61,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         libvirt__network_name: 'harvester',
         mac: @settings['harvester_network_config']['cluster'][node_number]['mgmt_mac']
 
+      harvester_node.ssh.host = "#{@settings['harvester_network_config']['cluster'][node_number]['ip']}"
+      harvester_node.ssh.username = "rancher"
+
       harvester_node.vm.provider :libvirt do |libvirt|
+        libvirt.qemu_use_agent = true
+        libvirt.mgmt_attach = false
         libvirt.cpu_mode = 'host-passthrough'
         libvirt.memory = @settings['harvester_network_config']['cluster'][node_number].key?('memory') ? @settings['harvester_network_config']['cluster'][node_number]['memory'] : @settings['harvester_node_config']['memory'] 
         libvirt.cpus = @settings['harvester_network_config']['cluster'][node_number].key?('cpu') ? @settings['harvester_network_config']['cluster'][node_number]['cpu'] : @settings['harvester_node_config']['cpu']

--- a/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
+++ b/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
@@ -21,7 +21,7 @@ subnet {{ settings['harvester_network_config']['dhcp_server']['subnet'] }} netma
     next-server {{ settings['harvester_network_config']['dhcp_server']['ip'] }};
 
    if exists user-class and option user-class = "iPXE" {
-        filename "http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/${net1/mac}";
+        filename "http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/${net0/mac}";
     } elsif option arch != 00:00 {
         filename "ipxe/ipxe.efi";
     } else {

--- a/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
@@ -38,7 +38,8 @@
     src: ipxe-create.j2
     dest: /var/www/harvester/{{ settings['harvester_network_config']['cluster'][0]['mgmt_mac']|lower }}
   vars:
-    boot_interface: "{{ settings['harvester_network_config']['cluster'][0]['vagrant_nic'] }}"
+    boot_interface: "{{ settings['harvester_network_config']['cluster'][0]['mgmt_nic'] }}"
+    boot_server_address: "{{ settings['harvester_network_config']['dhcp_server']['ip'] }}"
 
 - name: create boot entry for the cluster members
   template:
@@ -46,7 +47,8 @@
     dest: /var/www/harvester/{{ settings['harvester_network_config']['cluster'][item|int]['mgmt_mac']|lower }}
   vars:
     node_number: "{{ item }}"
-    boot_interface: "{{ settings['harvester_network_config']['cluster'][item|int]['vagrant_nic'] }}"
+    boot_interface: "{{ settings['harvester_network_config']['cluster'][item|int]['mgmt_nic'] }}"
+    boot_server_address: "{{ settings['harvester_network_config']['dhcp_server']['ip'] }}"
   with_sequence: "start=1 end={{ end_sequence }}"
 
 - name: download Harvester kernel

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2
@@ -31,7 +31,7 @@ install:
     - name: {{ settings['harvester_network_config']['cluster'][0]['mgmt_nic'] }}
     method: dhcp
   device: /dev/vda       # The target disk to install
-  iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso
+  iso_url: http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-amd64.iso
 #  tty: ttyS1,115200n8   # For machines without a VGA console
   tty: ttyS0
   vip: {{ settings['harvester_network_config']['vip']['ip'] }}

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-join.yaml.j2
@@ -32,6 +32,6 @@ install:
     - name: {{ settings['harvester_network_config']['cluster'][node_number | int]['mgmt_nic'] }}
     method: dhcp
   device: /dev/vda       # The target disk to install
-  iso_url: http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-amd64.iso
+  iso_url: http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-amd64.iso
 #  tty: ttyS1,115200n8   # For machines without a VGA console
   tty: ttyS0

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-create.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-create.j2
@@ -1,6 +1,6 @@
 #!ipxe
 
-kernel http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-vmlinuz-amd64
-initrd http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-initrd-amd64
-imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 ip={{ boot_interface }}:dhcp net.ifnames=1 rd.cos.disable rd.live.debug=1 rd.noverifyssl root=live:http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-rootfs-amd64.squashfs console=tty1 harvester.install.automatic=true harvester.install.skipchecks=true harvester.install.config_url=http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/config-create.yaml
+kernel http://{{ boot_server_address }}/harvester/harvester-vmlinuz-amd64
+initrd http://{{ boot_server_address }}/harvester/harvester-initrd-amd64
+imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 ip={{ boot_interface }}:dhcp net.ifnames=1 rd.cos.disable rd.live.debug=1 rd.noverifyssl root=live:http://{{ boot_server_address }}/harvester/harvester-rootfs-amd64.squashfs console=tty1 harvester.install.automatic=true harvester.install.skipchecks=true harvester.install.config_url=http://{{ boot_server_address }}/harvester/config-create.yaml
 boot

--- a/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-join.j2
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/templates/ipxe-join.j2
@@ -1,6 +1,6 @@
 #!ipxe
 
-kernel http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-vmlinuz-amd64
-initrd http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}/harvester/harvester-initrd-amd64
-imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 ip={{ boot_interface }}:dhcp net.ifnames=1 rd.cos.disable rd.live.debug=1 rd.noverifyssl root=live:http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/harvester-rootfs-amd64.squashfs console=tty1 harvester.install.automatic=true harvester.install.skipchecks=true harvester.install.config_url=http://{{ hostvars['pxe_server']['ansible_eth0']['ipv4']['address'] }}/harvester/config-join-{{ node_number }}.yaml
+kernel http://{{ boot_server_address }}/harvester/harvester-vmlinuz-amd64
+initrd http://{{ boot_server_address }}/harvester/harvester-initrd-amd64
+imgargs harvester-vmlinuz-amd64 initrd=harvester-initrd-amd64 ip={{ boot_interface }}:dhcp net.ifnames=1 rd.cos.disable rd.live.debug=1 rd.noverifyssl root=live:http://{{ boot_server_address }}/harvester/harvester-rootfs-amd64.squashfs console=tty1 harvester.install.automatic=true harvester.install.skipchecks=true harvester.install.config_url=http://{{ boot_server_address }}/harvester/config-join-{{ node_number }}.yaml
 boot

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -64,7 +64,6 @@ harvester_network_config:
       cpu: 8
       memory: 16384
       disk_size: 500G
-      vagrant_nic: ens5
       mgmt_nic: ens6
       mgmt_mac: 02:00:00:0D:62:E2
     - ip: 192.168.0.31
@@ -72,7 +71,6 @@ harvester_network_config:
       cpu: 8
       memory: 16384
       disk_size: 500G
-      vagrant_nic: ens5
       mgmt_nic: ens6
       mgmt_mac: 02:00:00:35:86:92
     - ip: 192.168.0.32
@@ -80,7 +78,6 @@ harvester_network_config:
       cpu: 8
       memory: 16384
       disk_size: 500G
-      vagrant_nic: ens5
       mgmt_nic: ens6
       mgmt_mac: 02:00:00:2F:F2:2A
     - ip: 192.168.0.33
@@ -88,7 +85,6 @@ harvester_network_config:
       cpu: 8
       memory: 8192
       disk_size: 500G
-      vagrant_nic: ens5
       mgmt_nic: ens6
       mgmt_mac: 02:00:00:A7:E6:FF
 


### PR DESCRIPTION
Enable Quemu guest agent and SSH access via `vagrant ssh` to Harvester nodes.
Remove Vagrant management network from Harvester nodes.

This change adds a virtual channel device for the Qemu guest agent to each Harvester node. Doing this enables Vagrant to accurately and quickly retrieve information about the running status of the Harvester nodes and manage the power state properly. In other words `vagrant status` works properly.

This change also adds SSH access information for Vagrant to allow users to gain SSH access to the Harvester nodes via `vagrant ssh`. This removes the need to configure the user's SSH keys in the settings - though that is still supported.

Lastly the Vagrant management network is removed from the Harvester nodes. This network is usually used by Vagrant to apply provisioning steps or to gain SSH access, but since the Harvester nodes are not provisioned through Vagrant boxes this network did not provide any function.
By removing this network from the Harvester nodes, Vagrant is no longer confused about which SSH access to use for Harvester nodes and `vagrant ssh` works.

#### Problem:

`vagrant ssh` command does not work properly and `vagrant status` gives inaccurate information about the state of the Harvester nodes.

Since the Harvester nodes aren't installed from Vagrant boxes, they don't match Vagrant's expectations when it comes to communication channels. As a result Vagrant has difficulties accurately retrieving VM status information via the Qemu guest agent and gaining SSH access to the Harvester nodes.

#### Solution:

The Harvester installer image already provides the Qemu guest agent. All that is needed is to configure libvirt to add a Qemu guest agent channel to the domain configuration to enable use of the Qemu guest agent for power status information and control.

Similarly, Vagrant has trouble gaining SSH access, since the Harvester nodes aren't using the default network and user configuration expected from Vagrant boxes. By configuring the network address and username explicitly and disabling the Vagrant management network, SSH access through `vagrant ssh` is possible, since Vagrant is no longer confused about what information to use to gain SSH access.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:

- `vagrant ssh` should work as intended and give SSH access to Harvester nodes without the need to explicitly configure SSH keys
- `vagrant status` should accurately display the power state of the Harvester nodes
- power control commands like `vagrant up` or `vagrant destroy` should execute quickly and yield the desired results

#### Additional documentation or context
