### PR TITLE
Config OVMF loader path for difference OS

### DIFF
--- a/vagrant-pxe-harvester/Vagrantfile
+++ b/vagrant-pxe-harvester/Vagrantfile
@@ -73,9 +73,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         boot_network = {'network' => 'harvester'}
         libvirt.boot 'hd'
         libvirt.boot boot_network
+
+        os_release = `cat /etc/os-release`.downcase
+        loader_path = if os_release.include?("ubuntu")
+            "/usr/share/qemu/OVMF.fd"
+        else
+            "/usr/share/qemu/ovmf-x86_64.bin"
+        end
         # NOTE: default to UEFI boot. Comment this out for legacy BIOS.
-        libvirt.loader = '/usr/share/qemu/ovmf-x86_64.bin'
-        libvirt.nic_model_type = 'virtio'
+        libvirt.loader = loader_path
+        libvirt.nic_model_type = 'e1000'
       end
     end
   end


### PR DESCRIPTION
#### Problem:
In previous PR only handle ovmf file in OpenSUSE.
This PR checks paths for different OSes

#### Solution:
```
ovmf_ubuntu = '/usr/share/qemu/OVMF.fd'
ovmf_opensuse = '/usr/share/qemu/ovmf-x86_64.bin'
if File.exist?(ovmf_ubuntu)
    libvirt.loader = ovmf_ubuntu
    libvirt.nic_model_type = 'e1000'
elsif File.exist?(ovmf_opensuse)
    libvirt.loader = ovmf_opensuse
    libvirt.nic_model_type = 'e1000'
end
```

#### Related Issue(s):
* harvester/ipxe-examples/pull/90

#### Test plan:
manual

#### Additional documentation or context
OK to provision a cluster
![image](https://github.com/user-attachments/assets/4d491673-6c5e-491d-97e0-8c23d5087cb7)
