### PR TITLE
Add S3 backup target

### DIFF
--- a/vagrant-pxe-harvester/Vagrantfile
+++ b/vagrant-pxe-harvester/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   
   # PXE Server
   config.vm.define :pxe_server do |pxe_server|
-    pxe_server.vm.box = 'generic/debian10'
+    pxe_server.vm.box = 'generic/debian11'
     pxe_server.vm.hostname = 'pxe-server'
     pxe_server.vm.network 'private_network',
       ip: @settings['harvester_network_config']['dhcp_server']['ip'],
@@ -39,8 +39,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     pxe_server.vm.provider :libvirt do |libvirt|
       libvirt.cpu_mode = 'host-passthrough'
-      libvirt.memory = '1024'
-      libvirt.cpus = '1'
+
+      # If S3 backup target is enabled, allocate a little more CPU and memory
+      # and create a suitable storage volume
+      if @settings['s3']['enabled']
+        libvirt.memory = '4096'
+        libvirt.cpus = '2'
+        libvirt.storage :file,
+          size: @settings['s3']['capacity'],
+          type: 'qcow2',
+          bus: 'virtio',
+          device: 'vdb'
+      else
+        libvirt.memory = '1024'
+        libvirt.cpus = '1'
+      end
     end
 
     pxe_server.vm.provision :ansible do |ansible|

--- a/vagrant-pxe-harvester/ansible/roles/s3/tasks/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/s3/tasks/main.yml
@@ -5,6 +5,27 @@
       - podman
       - python3-boto3
       - python3-packaging
+      - xfsprogs
+
+- name: create filesystem for backup target
+  community.general.filesystem:
+    fstype: xfs
+    dev: /dev/vdb
+
+- name: create data directory
+  ansible.builtin.file:
+    path: /data
+    owner: root
+    group: root
+    mode: '0755'
+    state: directory
+
+- name: mount backup target filesystem
+  ansible.posix.mount:
+    path: /data
+    src: /dev/vdb
+    fstype: xfs
+    state: mounted
 
 - name: start minio container
   containers.podman.podman_container:
@@ -21,11 +42,13 @@
     env:
       MINIO_ROOT_USER: "{{ settings['s3']['username'] }}"
       MINIO_ROOT_PASSWORD: "{{ settings['s3']['password'] }}"
+    volumes:
+      - "/data:/data"
     state: started
 
 - name: create default bucket
   amazon.aws.s3_bucket:
-    endpoint_url: "http://{{ settings['harvester_network_config']['dhcp_server']['ip']:9000/"
+    endpoint_url: "http://{{ settings['harvester_network_config']['dhcp_server']['ip'] }}:9000/"
     validate_certs: false
     access_key: "{{ settings['s3']['username'] }}"
     secret_key: "{{ settings['s3']['password'] }}"

--- a/vagrant-pxe-harvester/ansible/roles/s3/tasks/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/s3/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: install packages
+  ansible.builtin.apt:
+    pkg:
+      - podman
+      - python3-boto3
+      - python3-packaging
+
+- name: start minio container
+  containers.podman.podman_container:
+    name: minio
+    image: quay.io/minio/minio:latest
+    command:
+      - server
+      - /data
+      - --console-address
+      - ":9001"
+    ports:
+      - "{{ settings['s3']['port'] }}:9000"
+      - "{{ settings['s3']['console_port'] }}:9001"
+    env:
+      MINIO_ROOT_USER: "{{ settings['s3']['username'] }}"
+      MINIO_ROOT_PASSWORD: "{{ settings['s3']['password'] }}"
+    state: started
+
+- name: create default bucket
+  amazon.aws.s3_bucket:
+    endpoint_url: "http://{{ settings['harvester_network_config']['dhcp_server']['ip']:9000/"
+    validate_certs: false
+    access_key: "{{ settings['s3']['username'] }}"
+    secret_key: "{{ settings['s3']['password'] }}"
+    name: backups
+    state: present

--- a/vagrant-pxe-harvester/ansible/setup_pxe_server.yml
+++ b/vagrant-pxe-harvester/ansible/setup_pxe_server.yml
@@ -14,3 +14,5 @@
     - role: harvester
     - role: proxy
       when: settings['harvester_network_config']['offline']
+    - role: s3
+      when: settings['s3']['enabled'] | bool

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -145,6 +145,7 @@ rancher_config:
 # The S3 service will be available at http://<dhcp-server-ip>:9000
 s3:
   enabled: false
+  capacity: '300G'
   port: 9000
   console_port: 9001
   username: admin

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -138,3 +138,14 @@ rancher_config:
   password: password1234
   cpu: 2
   memory: 4096
+
+# Settings for an S3 backup target.
+# When enabled, this will spin up a Minio container on the PXE server, which can
+# act as a backup target.
+# The S3 service will be available at http://<dhcp-server-ip>:9000
+s3:
+  enabled: false
+  port: 9000
+  console_port: 9001
+  username: admin
+  password: password1234


### PR DESCRIPTION
Add an S3 backup target to the PXE server.

For testing and developing backup related features, this makes the iPXE environment a little more convenient by making a Minio instance available on the PXE server.

#### Problem:

When testing or developing backup related features (e.g. https://github.com/harvester/harvester/issues/7885) it may be necessary to have a working backup target available in the development environment.

#### Solution:

In an iPXE development environment there is a dedicated VM for hosting services like the DHCP needed for PXE boot. When required, this VM should also host a Minio container, which can serve as an S3 backup target