### PR TITLE
feat: Debug Mode with ipxe-examples Vagrant

### DIFF
--- a/vagrant-pxe-harvester/Vagrantfile
+++ b/vagrant-pxe-harvester/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # containerd is taking more than 60 seconds to shutdown in SUSE platforms
   # so increase the timeout to 120 seconds
   config.vm.graceful_halt_timeout = 120
-  
+
   # PXE Server
   config.vm.define :pxe_server do |pxe_server|
     pxe_server.vm.box = 'generic/debian11'
@@ -58,6 +58,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     pxe_server.vm.provision :ansible do |ansible|
       ansible.playbook = 'ansible/setup_pxe_server.yml'
+      ansible.verbose = @settings['overall_debug'] ? "-vvvv" : "-v"
       ansible.extra_vars = {
         settings: @settings
       }
@@ -81,7 +82,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         libvirt.qemu_use_agent = true
         libvirt.mgmt_attach = false
         libvirt.cpu_mode = 'host-passthrough'
-        libvirt.memory = @settings['harvester_network_config']['cluster'][node_number].key?('memory') ? @settings['harvester_network_config']['cluster'][node_number]['memory'] : @settings['harvester_node_config']['memory'] 
+        libvirt.memory = @settings['harvester_network_config']['cluster'][node_number].key?('memory') ? @settings['harvester_network_config']['cluster'][node_number]['memory'] : @settings['harvester_node_config']['memory']
         libvirt.cpus = @settings['harvester_network_config']['cluster'][node_number].key?('cpu') ? @settings['harvester_network_config']['cluster'][node_number]['cpu'] : @settings['harvester_node_config']['cpu']
         libvirt.storage :file,
           size: @settings['harvester_network_config']['cluster'][node_number].key?('disk_size') ? @settings['harvester_network_config']['cluster'][node_number]['disk_size'] : @settings['harvester_node_config']['disk_size'],
@@ -123,6 +124,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       rancher.vm.provision :ansible do |ansible|
         ansible.playbook = 'ansible/setup_rancher.yml'
+        ansible.verbose = @settings['overall_debug'] ? "-vvvv" : "-v"
         ansible.extra_vars = {
           settings: @settings
         }

--- a/vagrant-pxe-harvester/ansible/boot_harvester_node.yml
+++ b/vagrant-pxe-harvester/ansible/boot_harvester_node.yml
@@ -18,7 +18,7 @@
 
 - name: boot Harvester Node {{ node_number }}
   shell: >
-    vagrant up harvester-node-{{ node_number }}
+    {{ vagrantlognested }} vagrant up harvester-node-{{ node_number }}
   register: harvester_node_boot_result
 
 # Check node get ready

--- a/vagrant-pxe-harvester/ansible/setup_harvester.yml
+++ b/vagrant-pxe-harvester/ansible/setup_harvester.yml
@@ -5,58 +5,62 @@
   gather_facts: false
 
   tasks:
-  - debug:
-      msg: Installation Started
+    - debug:
+        msg: Installation Started
 
-  - name: install PXE server
-    shell: >
-      vagrant up pxe_server
-    register: pxe_server_installation_result
+    - name: set vagrant log
+      set_fact:
+        vagrantlog: "VAGRANT_LOG={{ 'debug' if overall_debug else 'info' }}"
 
-  - name: get the IP address of pxe_server
-    shell: |
-      vagrant ssh-config pxe_server 2>/dev/null | grep HostName | awk '{ print $2 }'
-    register: get_pxe_server_ip_result
-    until: get_pxe_server_ip_result != ""
-    retries: 10
-    delay: 60
+    - name: install PXE server
+      shell: >
+        {{ vagrantlog }} vagrant up pxe_server
+      register: pxe_server_installation_result
 
-  - name: set pxe_server_ip fact
-    set_fact:
-      pxe_server_ip: "{{ get_pxe_server_ip_result.stdout }}"
+    - name: get the IP address of pxe_server
+      shell: |
+        vagrant ssh-config pxe_server 2>/dev/null | grep HostName | awk '{ print $2 }'
+      register: get_pxe_server_ip_result
+      until: get_pxe_server_ip_result != ""
+      retries: 10
+      delay: 60
 
-  - name: wait for PXE server HTTP port to get ready
-    uri:
-      url: "http://{{ pxe_server_ip }}/harvester/config-create.yaml"
-      status_code: 200
-    register: pxe_server_http_result
-    until: pxe_server_http_result.status == 200
-    retries: 10
-    delay: 30
+    - name: set pxe_server_ip fact
+      set_fact:
+        pxe_server_ip: "{{ get_pxe_server_ip_result.stdout }}"
 
-  - name: boot Harvester nodes
-    include_tasks: boot_harvester_node.yml
-    vars:
-      node_number: "{{ item }}"
-    with_sequence: 0-{{ harvester_cluster_nodes|int - 1 }}
+    - name: wait for PXE server HTTP port to get ready
+      uri:
+        url: "http://{{ pxe_server_ip }}/harvester/config-create.yaml"
+        status_code: 200
+      register: pxe_server_http_result
+      until: pxe_server_http_result.status == 200
+      retries: 10
+      delay: 30
 
-  - name: install Rancher {{ rancher_config.version }}
-    shell: >
-      vagrant up rancher
-    when: rancher_config.enabled
+    - name: boot Harvester nodes
+      include_tasks: boot_harvester_node.yml
+      vars:
+        node_number: "{{ item }}"
+        vagrantlognested: "{{ vagrantlog }}"
+      with_sequence: 0-{{ harvester_cluster_nodes|int - 1 }}
 
-  - name: wait for Rancher {{ rancher_config.hostname }} to get ready
-    uri:
-      url: "https://{{ rancher_config.hostname }}"
-      validate_certs: no
-      status_code: 200
-      force: true
-    register: http_resp
-    until: http_resp.status == 200
-    retries: 10
-    delay: 60
-    when: rancher_config.enabled
+    - name: install Rancher {{ rancher_config.version }}
+      shell: >
+        {{ vagrantlog }} vagrant up rancher
+      when: rancher_config.enabled
 
-  - debug:
-      msg: Installation Completed
+    - name: wait for Rancher {{ rancher_config.hostname }} to get ready
+      uri:
+        url: "https://{{ rancher_config.hostname }}"
+        validate_certs: no
+        status_code: 200
+        force: true
+      register: http_resp
+      until: http_resp.status == 200
+      retries: 10
+      delay: 60
+      when: rancher_config.enabled
 
+    - debug:
+        msg: Installation Completed

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -25,6 +25,12 @@ harvester_rootfs_url: https://releases.rancher.com/harvester/master/harvester-ma
 harvester_cluster_nodes: 3
 
 #
+# extra helper flags
+#
+# Helper flags that can assist in providing input for the overall install
+overall_debug: false
+
+#
 # network_config
 #
 # Harvester network configurations.
@@ -48,7 +54,7 @@ harvester_network_config:
     dns_server: 1.1.1.1
 
   dns_servers:
-  # This is a list of DNS servers that will be included in your Harvester OS config
+    # This is a list of DNS servers that will be included in your Harvester OS config
     - 192.168.0.254
     - 8.8.8.8
 
@@ -124,7 +130,7 @@ harvester_node_config:
 #
 # Rancher setup on K3s cluster.
 # Refer support matrix on https://ranchermanager.docs.rancher.com/versions
-# 
+#
 rancher_config:
   enabled: false
 
@@ -145,7 +151,7 @@ rancher_config:
 # The S3 service will be available at http://<dhcp-server-ip>:9000
 s3:
   enabled: false
-  capacity: '300G'
+  capacity: "300G"
   port: 9000
   console_port: 9001
   username: admin

--- a/vagrant-pxe-harvester/setup_harvester.sh
+++ b/vagrant-pxe-harvester/setup_harvester.sh
@@ -4,7 +4,13 @@ MYNAME=$0
 ROOTDIR=$(dirname $(readlink -e $MYNAME))
 
 pushd $ROOTDIR
-ansible-playbook ansible/setup_harvester.yml --extra-vars "@settings.yml"
+if grep -Fxq "overall_debug: true" $ROOTDIR/settings.yml
+then
+    echo "vagrant-pxe-harvester, debug enabled..."
+    ANSIBLE_VERBOSITY=7 ansible-playbook ansible/setup_harvester.yml --extra-vars "@settings.yml"
+else
+    ansible-playbook ansible/setup_harvester.yml --extra-vars "@settings.yml"
+fi
 ANSIBLE_PLAYBOOK_RESULT=$?
 popd
 exit $ANSIBLE_PLAYBOOK_RESULT


### PR DESCRIPTION
* allow for debug mode when provisioning

#### Problem:
Debugging

#### Solution:
Enable debugging via settings flag, for both Ansible & Vagrant elements

#### Related Issue(s):
N/A

#### Test plan:
Test provisioning succeeds with debug enabled & disabled.
With debugging enabled, should see a lot more underlying logs fired off in standard out in the terminal.

#### Additional documentation or context
N/A, self documented in comments of settings.yml