### PR TITLE
feat: Allow Rancher Alpha and other devel based versions on Helm install

### DIFF
--- a/vagrant-pxe-harvester/ansible/setup_rancher.yml
+++ b/vagrant-pxe-harvester/ansible/setup_rancher.yml
@@ -8,9 +8,13 @@
   any_errors_fatal: true
   vars:
     kubeconfig: /etc/rancher/k3s/k3s.yaml
-  
+
   tasks:
-    - name: setup k3s 
+    - name: determine if Rancher to be installed needs devel flag or not
+      set_fact:
+        develflag: "{{ ' --devel' if settings.rancher_config.devel else '' }}"
+
+    - name: setup k3s
       shell: curl -sfL https://get.k3s.io | sh -
       environment:
         INSTALL_K3S_CHANNEL: "{{ settings.rancher_config.k3s_channel }}"
@@ -38,7 +42,7 @@
         helm install rancher rancher/rancher
         --namespace cattle-system
         --create-namespace
-        --version {{ settings.rancher_config.version }}
+        --version {{ settings.rancher_config.version }}{{ develflag }}
         --set bootstrapPassword={{ settings.rancher_config.password }}
         --set hostname={{ settings.rancher_config.hostname }}
       environment:

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -48,7 +48,7 @@ harvester_network_config:
     dns_server: 1.1.1.1
 
   dns_servers:
-  # This is a list of DNS servers that will be included in your Harvester OS config
+    # This is a list of DNS servers that will be included in your Harvester OS config
     - 192.168.0.254
     - 8.8.8.8
 
@@ -124,7 +124,7 @@ harvester_node_config:
 #
 # Rancher setup on K3s cluster.
 # Refer support matrix on https://ranchermanager.docs.rancher.com/versions
-# 
+#
 rancher_config:
   enabled: false
 
@@ -138,6 +138,8 @@ rancher_config:
   password: password1234
   cpu: 2
   memory: 4096
+  # to allow for like "alpha" builds of Rancher
+  devel: false
 
 # Settings for an S3 backup target.
 # When enabled, this will spin up a Minio container on the PXE server, which can
@@ -145,7 +147,7 @@ rancher_config:
 # The S3 service will be available at http://<dhcp-server-ip>:9000
 s3:
   enabled: false
-  capacity: '300G'
+  capacity: "300G"
   port: 9000
   console_port: 9001
   username: admin


### PR DESCRIPTION
* allow for Rancher alpha installs or any other Rancher installs from Helm that depend on the devel flag being present

Resolves: feat/allow-for-rancher-alpha

#### Problem:
Example, try this:
```
$ helm search repo rancher-alpha -l | grep -ie "2.12.0"
# where, `rancher-alpha` is---> rancher-alpha             	https://releases.rancher.com/server-charts/alpha                                 
```
Now try it with the `--devel` flag:
```
$ helm search repo rancher-alpha -l --devel | grep -ie "2.12.0"
# now you'll get a lot of results back, like `v2.12.0-alpha17` for instance
```
So with those ^ that's where the problem sits.
If we want ipxe-examples to be able to install a "pre-release" / "--devel" chart from helm of Rancher, we can't.

#### Solution:
This PR fixes that issue, allowing us to give the settings.yml a bool to represent whether or not the helm repo + version of Rancher we are trying to install is going to need a `--devel` flag.
Rancher is constantly releasing and it's difficult to stay on top of things, this hopefully helps out w/ some things a little bit.

#### Related Issue(s):
N/A , issue is more internal house-keeping / trying to make things hopefully a tad more easier (though some scenarios this may be more of a headache than not, depending on resource intensity etc.)

#### Test plan:
1. in settings.yml, set rancher_config.enabled to `true`
2. in settings.yml, set k3s_channel to `v1.31`
3. in settngs.yml, set repo to `https://releases.rancher.com/server-charts/alpha`
4. in settings.yml, set devel to `true`
5. run `./setup_harvester.sh`, expect that Rancher v2.12.0-alpha17 is up and running 

#### Additional documentation or context
Generally self documenting code comment in the settings.yml as to what this does.
