### PR TITLE
Add a new cluster network interface ens7

### DIFF
--- a/vagrant-pxe-harvester/Vagrantfile
+++ b/vagrant-pxe-harvester/Vagrantfile
@@ -34,7 +34,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     pxe_server.vm.network 'private_network',
       ip: @settings['harvester_network_config']['dhcp_server']['ip'],
       libvirt__network_name: 'harvester',
-      # don't enable DHCP as this node will have it's now DHCP server for iPXE
+      # don't enable DHCP as this node will have its own DHCP server for iPXE
+      libvirt__dhcp_enabled: false
+    pxe_server.vm.network 'private_network',
+      ip: @settings['harvester_network_config']['dhcp_server']['cnet_ip'],
+      libvirt__network_name: 'harvester-cnet',
+      # don't enable DHCP as this node will have its own DHCP server for iPXE
       libvirt__dhcp_enabled: false
 
     pxe_server.vm.provider :libvirt do |libvirt|
@@ -73,6 +78,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       harvester_node.vm.network 'private_network',
         libvirt__network_name: 'harvester',
         mac: @settings['harvester_network_config']['cluster'][node_number]['mgmt_mac']
+      harvester_node.vm.network 'private_network',
+        libvirt__network_name: 'harvester-cnet',
+        mac: @settings['harvester_network_config']['cluster'][node_number]['cnet_mac']
 
       harvester_node.ssh.host = "#{@settings['harvester_network_config']['cluster'][node_number]['ip']}"
       harvester_node.ssh.username = "rancher"

--- a/vagrant-pxe-harvester/ansible/roles/dhcp/files/isc-dhcp-server
+++ b/vagrant-pxe-harvester/ansible/roles/dhcp/files/isc-dhcp-server
@@ -18,4 +18,4 @@
 
 # On what interfaces should the DHCP server (dhcpd) serve DHCP requests?
 #	Separate multiple interfaces with spaces, e.g. "eth0 eth1".
-INTERFACESv4="eth1"
+INTERFACESv4="eth1 eth2"

--- a/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
+++ b/vagrant-pxe-harvester/ansible/roles/dhcp/templates/dhcpd.conf.j2
@@ -29,6 +29,17 @@ subnet {{ settings['harvester_network_config']['dhcp_server']['subnet'] }} netma
     }
 }
 
+subnet {{ settings['harvester_network_config']['dhcp_server']['cnet_subnet'] }} netmask {{ settings['harvester_network_config']['dhcp_server']['cnet_netmask'] }} {
+    range {{ settings['harvester_network_config']['dhcp_server']['cnet_range'] }};
+    option domain-name-servers {{ settings['harvester_network_config']['dhcp_server']['dns_server'] }}, {{ settings['harvester_network_config']['dhcp_server']['cnet_ip'] }}, 8.8.8.8;
+    {% if settings['harvester_network_config']['offline'] %}
+    option routers {{ settings['harvester_network_config']['dhcp_server']['cnet_ip'] }};
+    {% else %}
+    option routers {{ settings['harvester_network_config']['dhcp_server']['cnet_subnet'][:-1] }}1;
+    {% endif %}
+    next-server {{ settings['harvester_network_config']['dhcp_server']['cnet_ip'] }};
+}
+
 host harvest_vip {
     hardware ethernet {{ settings['harvester_network_config']['vip']['mac'] }};
     fixed-address {{ settings['harvester_network_config']['vip']['ip'] }};

--- a/vagrant-pxe-harvester/settings.yml
+++ b/vagrant-pxe-harvester/settings.yml
@@ -43,6 +43,10 @@ harvester_network_config:
     subnet: 192.168.0.0
     netmask: 255.255.255.0
     range: 192.168.0.50 192.168.0.130
+    cnet_ip: 192.168.124.254
+    cnet_subnet: 192.168.124.0
+    cnet_netmask: 255.255.255.0
+    cnet_range: 192.168.124.50 192.168.124.130
     https: false
     # Change this to a custom DNS server if you need one for your DHCP scope
     dns_server: 1.1.1.1
@@ -66,6 +70,8 @@ harvester_network_config:
       disk_size: 500G
       mgmt_nic: ens6
       mgmt_mac: 02:00:00:0D:62:E2
+      cnet_nic: ens7
+      cnet_mac: 02:00:00:0D:62:E3
     - ip: 192.168.0.31
       role: default
       cpu: 8
@@ -73,6 +79,8 @@ harvester_network_config:
       disk_size: 500G
       mgmt_nic: ens6
       mgmt_mac: 02:00:00:35:86:92
+      cnet_nic: ens7
+      cnet_mac: 02:00:00:35:86:93
     - ip: 192.168.0.32
       role: default
       cpu: 8
@@ -80,6 +88,8 @@ harvester_network_config:
       disk_size: 500G
       mgmt_nic: ens6
       mgmt_mac: 02:00:00:2F:F2:2A
+      cnet_nic: ens7
+      cnet_mac: 02:00:00:2F:F2:2B
     - ip: 192.168.0.33
       role: default
       cpu: 8
@@ -87,6 +97,8 @@ harvester_network_config:
       disk_size: 500G
       mgmt_nic: ens6
       mgmt_mac: 02:00:00:A7:E6:FF
+      cnet_nic: ens7
+      cnet_mac: 02:00:00:A7:E6:F0
 
 #
 # harvester_config


### PR DESCRIPTION
#### Problem:
Many regression test cases will use a non-mgmt NIC, however we only have mgmt NIC now.


#### Solution:
To better support local development, we should add the 2nd NIC.

#### Related Issue(s):
n/a

#### Verification
<img width="1565" height="774" alt="image" src="https://github.com/user-attachments/assets/7bc93901-adaa-4a29-8ce6-b242e36a4d13" />
<img width="1565" height="503" alt="image" src="https://github.com/user-attachments/assets/615122b4-fc02-44f0-bb12-8bb21e84cae7" />

#### Additional documentation or context
Metadata about this NIC in ipxe-example, you can specify following in `config.yml` in harvester/tests like:
```
vlan-id: 1
vlan-nic: 'ens7'
ip-pool-subnet: '192.168.124.0/24'
ip-pool-start: '192.168.124.200'
ip-pool-end: '192.168.124.210'
``` 