### PR TITLE
Avoid checking checksums for local files

### DIFF
--- a/vagrant-pxe-harvester/ansible/roles/harvester/tasks/_download_media.yml
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/tasks/_download_media.yml
@@ -10,31 +10,20 @@
 - name: get expected checksum for this media file
   set_fact:
     expected_checksum: "{{ harvester_checksums[media_basename] | default('') }}"
+  when: harvester_download_url_facts['scheme']|lower != 'file'
 
 - name: verify checksum is available
   fail:
     msg: "No SHA512 checksum found for {{ media_basename }} in the checksum file"
-  when: expected_checksum == ''
+  when:
+    - harvester_download_url_facts['scheme']|lower != 'file'
+    - expected_checksum == ''
 
 - name: copy Harvester media from local directory
-  copy:
+  ansible.builtin.copy:
     src: "{{ harvester_download_url_facts['path'] }}"
-    dest: /var/www/harvester/{{ media_filename }}
+    dest: "/var/www/harvester/{{ media_filename }}"
   when: harvester_download_url_facts['scheme']|lower == 'file'
-
-- name: verify checksum of copied local file
-  stat:
-    path: /var/www/harvester/{{ media_filename }}
-    checksum_algorithm: sha512
-  register: local_file_stat
-  when: harvester_download_url_facts['scheme']|lower == 'file'
-
-- name: fail if local file checksum doesn't match
-  fail:
-    msg: "Checksum mismatch for {{ media_filename }}. Expected: {{ expected_checksum }}, Got: {{ local_file_stat.stat.checksum }}"
-  when:
-    - harvester_download_url_facts['scheme']|lower == 'file'
-    - local_file_stat.stat.checksum != expected_checksum
 
 - name: debug - downloading from remote
   debug:
@@ -42,9 +31,9 @@
   when: harvester_download_url_facts['scheme']|lower != 'file'
 
 - name: download Harvester media with checksum verification
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ harvester_media_url }}"
-    dest: /var/www/harvester/{{ media_filename }}
+    dest: "/var/www/harvester/{{ media_filename }}"
     checksum: "sha512:{{ expected_checksum }}"
     timeout: "{{ settings['harvester_iso_download_and_sha512_check_timeout_seconds'] }}"
   when: harvester_download_url_facts['scheme']|lower != 'file'

--- a/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
@@ -43,22 +43,19 @@
     dest: /tmp/harvester.sha512
   when: harvester_sha512_url_facts['scheme']|lower != 'file'
 
-- name: copy Harvester SHA512 checksum file from local
-  copy:
-    src: "{{ harvester_sha512_url_facts['path'] }}"
-    dest: /tmp/harvester.sha512
-  when: harvester_sha512_url_facts['scheme']|lower == 'file'
-
 - name: read SHA512 checksum file
   slurp:
     src: /tmp/harvester.sha512
   register: sha512_content
+  when: harvester_sha512_url_facts['scheme']|lower != 'file'
 
 - name: parse SHA512 checksums into dictionary (line splitting)
   set_fact:
     harvester_checksums: "{{ harvester_checksums | default({}) | combine({item.split()[1]: item.split()[0]}) }}"
   loop: "{{ (sha512_content['content'] | b64decode).splitlines() }}"
-  when: item | trim | length > 0
+  when:
+    - item | trim | length > 0
+    - harvester_sha512_url_facts['scheme']|lower != 'file'
 
 - name: create boot entry for the first node
   template:


### PR DESCRIPTION
When setting up the PXE server, avoid checking checksums when copying the Harvester artifacts from local files.
There is no benefit to checking the checksums in this case, since whoever controls the local files can easily also provide a matching checksum file. However requiring the checks would make development/CI deployments more complicated when the artifacts are produced by a local build.
Checksums are still required when fetching Harvester artifacts from the network, e.g. for release versions.

#### Problem:

CI failures when deploying from local builds.

#### Solution:

Omit checking checksums when artifacts are sourced from local files.

#### Related Issue(s):

https://suse.slack.com/archives/C02D9459KFW/p1777453183192569

#### Test plan:

Deploying still works both with Harvester artifacts as local files, as well as when Harvester artifacts are sourced from the network. However in case Harvester artifacts are local files, the checksum file is ignored.

#### Additional documentation or context

CI failure example:
https://github.com/harvester/harvester-installer/pull/1273