### PR TITLE
No checksum for local files

### DIFF
--- a/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
+++ b/vagrant-pxe-harvester/ansible/roles/harvester/tasks/main.yml
@@ -43,19 +43,22 @@
     dest: /tmp/harvester.sha512
   when: harvester_sha512_url_facts['scheme']|lower != 'file'
 
+- name: copy Harvester SHA512 checksum file from local
+  copy:
+    src: "{{ harvester_sha512_url_facts['path'] }}"
+    dest: /tmp/harvester.sha512
+  when: harvester_sha512_url_facts['scheme']|lower == 'file'
+
 - name: read SHA512 checksum file
   slurp:
     src: /tmp/harvester.sha512
   register: sha512_content
-  when: harvester_sha512_url_facts['scheme']|lower != 'file'
 
 - name: parse SHA512 checksums into dictionary (line splitting)
   set_fact:
     harvester_checksums: "{{ harvester_checksums | default({}) | combine({item.split()[1]: item.split()[0]}) }}"
   loop: "{{ (sha512_content['content'] | b64decode).splitlines() }}"
-  when:
-    - item | trim | length > 0
-    - harvester_sha512_url_facts['scheme']|lower != 'file'
+  when: item | trim | length > 0
 
 - name: create boot entry for the first node
   template:


### PR DESCRIPTION
Add back the ability to use a local checksum file when fetching Harvester artifacts from remote server.

#### Problem:

https://github.com/harvester/ipxe-examples/pull/105#discussion_r3160254278

#### Solution:

Add back the ability to use a local checksum file

#### Related Issue(s):

N/A. https://github.com/harvester/ipxe-examples/pull/105#discussion_r3160254278

#### Test plan:

Deploying Harvester should work from local artifacts and remote artifacts. If using remote artifacts, it should be possible to use a local file for checksums.

#### Additional documentation or context
